### PR TITLE
Add CH_BASE path helpers and update examples

### DIFF
--- a/CombinePdfs/bin/SMLegacyMorphing.cpp
+++ b/CombinePdfs/bin/SMLegacyMorphing.cpp
@@ -11,6 +11,7 @@
 #include "CombineHarvester/CombineTools/interface/HttSystematics.h"
 #include "CombineHarvester/CombinePdfs/interface/MorphFunctions.h"
 #include "CombineHarvester/CombineTools/interface/BinByBin.h"
+#include "CombineHarvester/CombineTools/interface/PathTools.h"
 
 using namespace std;
 
@@ -21,11 +22,10 @@ int main() {
   typedef vector<pair<int, string>> Categories;
   typedef vector<string> VString;
 
-  string auxiliaries  = string(getenv("CMSSW_BASE")) + "/src/auxiliaries/";
-  string aux_shapes   = auxiliaries +"shapes/";
-  string aux_pruning  = auxiliaries +"pruning/";
-  string input_dir =
-      string(getenv("CMSSW_BASE")) + "/src/CombineHarvester/CombineTools/input";
+  string auxiliaries  = ch::paths::auxiliaries();
+  string aux_shapes   = auxiliaries + "shapes/";
+  string aux_pruning  = auxiliaries + "pruning/";
+  string input_dir    = ch::paths::input();
 
   VString chns =
       {"et", "mt", "em", "ee", "mm", "tt"};

--- a/CombineTools/bin/ChronoSpectra.cpp
+++ b/CombineTools/bin/ChronoSpectra.cpp
@@ -67,10 +67,10 @@
     cd CMSSW_14_1_0_pre4/src
     cmsenv
     git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
-    cd $CMSSW_BASE/src/HiggsAnalysis/CombinedLimit
+    cd $CH_BASE/../HiggsAnalysis/CombinedLimit
     git fetch origin
     git checkout v10.0.2
-    cd $CMSSW_BASE/src/
+    cd $CH_BASE
     git clone https://github.com/TheQuantiser/CombineHarvester.git
     scram b -j$(nproc)
     cmsenv

--- a/CombineTools/bin/Example1.cpp
+++ b/CombineTools/bin/Example1.cpp
@@ -1,14 +1,17 @@
 #include <string>
 #include <iostream>
 #include "CombineHarvester/CombineTools/interface/CombineHarvester.h"
+#include "CombineHarvester/CombineTools/interface/PathTools.h"
 
 using namespace std;
 
 int main() {
 
   //! [part1]
-  // Use the CMSSW_BASE environment variable to get the full path to the auxiliaries folder
-  string in_dir = string(getenv("CMSSW_BASE")) + "/src/auxiliaries/datacards/sm/htt_mt/";
+  // Use the CH_BASE environment variable to get the full path to the
+  // auxiliaries folder. If CH_BASE is not set the path is inferred
+  // automatically.
+  string in_dir = ch::paths::auxiliaries() + "datacards/sm/htt_mt/";
 
   // Create a new CombineHarvester instance
   ch::CombineHarvester cmb1;

--- a/CombineTools/bin/Example2.cpp
+++ b/CombineTools/bin/Example2.cpp
@@ -11,14 +11,16 @@
 #include "CombineHarvester/CombineTools/interface/Utilities.h"
 #include "CombineHarvester/CombineTools/interface/Systematics.h"
 #include "CombineHarvester/CombineTools/interface/BinByBin.h"
+#include "CombineHarvester/CombineTools/interface/PathTools.h"
 
 using namespace std;
 
 int main() {
   //! [part1]
   // First define the location of the "auxiliaries" directory where we can
-  // source the input files containing the datacard shapes
-  string aux_shapes = string(getenv("CMSSW_BASE")) + "/src/auxiliaries/shapes/";
+  // source the input files containing the datacard shapes. The base location
+  // is given by the CH_BASE environment variable.
+  string aux_shapes = ch::paths::auxiliaries() + "shapes/";
 
   // Create an empty CombineHarvester instance that will hold all of the
   // datacard configuration and histograms etc.

--- a/CombineTools/bin/MSSMExample.cpp
+++ b/CombineTools/bin/MSSMExample.cpp
@@ -12,6 +12,7 @@
 #include "CombineHarvester/CombineTools/interface/CardWriter.h"
 #include "CombineHarvester/CombineTools/interface/CopyTools.h"
 #include "CombineHarvester/CombineTools/interface/BinByBin.h"
+#include "CombineHarvester/CombineTools/interface/PathTools.h"
 
 using namespace std;
 
@@ -21,11 +22,10 @@ int main() {
   typedef vector<pair<int, string>> Categories;
   typedef vector<string> VString;
 
-  string auxiliaries  = string(getenv("CMSSW_BASE")) + "/src/auxiliaries/";
-  string aux_shapes   = auxiliaries +"shapes/";
-  string aux_pruning  = auxiliaries +"pruning/";
-  string input_dir =
-      string(getenv("CMSSW_BASE")) + "/src/CombineHarvester/CombineTools/input";
+  string auxiliaries  = ch::paths::auxiliaries();
+  string aux_shapes   = auxiliaries + "shapes/";
+  string aux_pruning  = auxiliaries + "pruning/";
+  string input_dir    = ch::paths::input();
 
 //So far only mutau added for MSSM, need to copy over all the systematics for other channels 
 

--- a/CombineTools/bin/MSSMUpdate.cpp
+++ b/CombineTools/bin/MSSMUpdate.cpp
@@ -12,6 +12,7 @@
 #include "CombineHarvester/CombineTools/interface/CardWriter.h"
 #include "CombineHarvester/CombineTools/interface/CopyTools.h"
 #include "CombineHarvester/CombineTools/interface/BinByBin.h"
+#include "CombineHarvester/CombineTools/interface/PathTools.h"
 
 using namespace std;
 
@@ -24,10 +25,10 @@ int main(int argc, char** argv) {
  
   string SM125        = "";
   if(argc>1) SM125    = string(argv[1]);
-  string auxiliaries  = string(getenv("CMSSW_BASE")) + "/src/auxiliaries/";
-  string aux_shapes   = auxiliaries +"shapes/";
-  string aux_pruning  = auxiliaries +"pruning/";
-  string input_dir    = string(getenv("CMSSW_BASE")) + "/src/CombineHarvester/CombineTools/input";
+  string auxiliaries  = ch::paths::auxiliaries();
+  string aux_shapes   = auxiliaries + "shapes/";
+  string aux_pruning  = auxiliaries + "pruning/";
+  string input_dir    = ch::paths::input();
 
   VString chns =
       {"mt", "et", "tt", "em", "mm"};

--- a/CombineTools/bin/SMLegacyExample.cpp
+++ b/CombineTools/bin/SMLegacyExample.cpp
@@ -12,6 +12,7 @@
 #include "CombineHarvester/CombineTools/interface/CardWriter.h"
 #include "CombineHarvester/CombineTools/interface/CopyTools.h"
 #include "CombineHarvester/CombineTools/interface/BinByBin.h"
+#include "CombineHarvester/CombineTools/interface/PathTools.h"
 
 using namespace std;
 
@@ -21,11 +22,10 @@ int main() {
   typedef vector<pair<int, string>> Categories;
   typedef vector<string> VString;
 
-  string auxiliaries  = string(getenv("CMSSW_BASE")) + "/src/auxiliaries/";
-  string aux_shapes   = auxiliaries +"shapes/";
-  string aux_pruning  = auxiliaries +"pruning/";
-  string input_dir =
-      string(getenv("CMSSW_BASE")) + "/src/CombineHarvester/CombineTools/input";
+  string auxiliaries  = ch::paths::auxiliaries();
+  string aux_shapes   = auxiliaries + "shapes/";
+  string aux_pruning  = auxiliaries + "pruning/";
+  string input_dir    = ch::paths::input();
 
   VString chns =
       {"et", "mt", "em", "ee", "mm", "tt"};

--- a/CombineTools/interface/PathTools.h
+++ b/CombineTools/interface/PathTools.h
@@ -1,0 +1,20 @@
+#ifndef CombineTools_PathTools_h
+#define CombineTools_PathTools_h
+#include <string>
+
+namespace ch {
+namespace paths {
+// Return the base directory of the CombineHarvester repository.
+// Uses the CH_BASE environment variable if set, otherwise attempts to
+// discover the location by searching upwards from the current directory.
+std::string base();
+
+// Path to the external auxiliaries directory.
+std::string auxiliaries();
+
+// Path to the CombineTools input directory.
+std::string input();
+}
+}
+
+#endif

--- a/CombineTools/src/PathTools.cc
+++ b/CombineTools/src/PathTools.cc
@@ -1,0 +1,36 @@
+#include "CombineHarvester/CombineTools/interface/PathTools.h"
+#include <cstdlib>
+#include <string>
+#include <boost/filesystem.hpp>
+
+namespace ch {
+namespace paths {
+
+std::string base() {
+  const char* env = std::getenv("CH_BASE");
+  if (env) return std::string(env);
+  boost::filesystem::path p = boost::filesystem::current_path();
+  while (true) {
+    if (boost::filesystem::exists(p / "CombineTools") &&
+        boost::filesystem::exists(p / "CombinePdfs")) {
+      return p.string();
+    }
+    if (p.has_parent_path()) {
+      p = p.parent_path();
+    } else {
+      break;
+    }
+  }
+  return "";
+}
+
+std::string auxiliaries() {
+  return base() + "/../auxiliaries/";
+}
+
+std::string input() {
+  return base() + "/CombineTools/input";
+}
+
+}  // namespace paths
+}  // namespace ch

--- a/README.md
+++ b/README.md
@@ -18,3 +18,20 @@ A new full release area can be set up and compiled in the following steps:
     scram b
 
 Previously this package contained some analysis-specific subpackages. These packages can now be found [here](https://gitlab.cern.ch/cms-hcg/ch-areas). If you would like a repository for your analysis package to be created in that group, please create an issue in the CombineHarvester repository stating the desired package name and your NICE username. Note: you are not obliged to store your analysis package in this central group.
+
+## Repository layout and `CH_BASE`
+
+Many of the standalone utilities and examples use the environment variable
+`CH_BASE` to locate input files. This variable should point to the root of the
+CombineHarvester repository. If it is not set, the tools will attempt to infer
+the location automatically. The expected default layout is
+
+```
+$CH_BASE/            # Clone of this repository
+$CH_BASE/CombineTools/input/
+$CH_BASE/../auxiliaries/     # Optional external data repository
+```
+
+In the examples the helper functions in `CombineTools/interface/PathTools.h`
+provide convenient access to these locations, e.g. `ch::paths::auxiliaries()`
+and `ch::paths::input()`.


### PR DESCRIPTION
## Summary
- add PathTools utilities for resolving repository directories using new `CH_BASE` environment variable
- refactor example binaries to use PathTools instead of `CMSSW_BASE`
- document `CH_BASE` layout in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba8826b0c48329a4ba3f32d57f47d8