### PR TITLE
feat: support standalone combine binary

### DIFF
--- a/CombineTools/python/combine/CombineToolBase.py
+++ b/CombineTools/python/combine/CombineToolBase.py
@@ -2,25 +2,29 @@ from __future__ import absolute_import
 from __future__ import print_function
 import os
 import stat
+import shutil
 from functools import partial
 from multiprocessing import Pool
 from six.moves import range
 
 DRY_RUN = False
 
-JOB_PREFIX = """#!/bin/sh
+
+def _build_job_prefix(cmssw_base, scram_arch, standalone):
+    cmssw_cmds = ''
+    if not standalone and cmssw_base and scram_arch:
+        cmssw_cmds = (
+            'cd {base}/src\n'
+            'export SCRAM_ARCH={arch}\n'
+            'source /cvmfs/cms.cern.ch/cmsset_default.sh\n'
+            'eval `scramv1 runtime -sh`\n'
+        ).format(base=cmssw_base, arch=scram_arch)
+    return """#!/bin/sh
 ulimit -s unlimited
 set -e
-cd %(CMSSW_BASE)s/src
-export SCRAM_ARCH=%(SCRAM_ARCH)s
-source /cvmfs/cms.cern.ch/cmsset_default.sh
-eval `scramv1 runtime -sh`
-cd %(PWD)s
-""" % ({
-    'CMSSW_BASE': os.environ['CMSSW_BASE'],
-    'SCRAM_ARCH': os.environ['SCRAM_ARCH'],
-    'PWD': os.environ['PWD']
-})
+{cmssw}
+cd {pwd}
+""".format(cmssw=cmssw_cmds, pwd=os.environ['PWD'])
 
 CONDOR_TEMPLATE = """executable = %(EXE)s
 arguments = $(ProcId)
@@ -89,8 +93,9 @@ process.options = cms.untracked.PSet()
 """
 
 
-def run_command(dry_run, command, pre_cmd=''):
+def run_command(dry_run, command, pre_cmd='', combine_exec='combine'):
     if command.startswith('combine'):
+        command = command.replace('combine', combine_exec, 1)
         command = pre_cmd + command
     if not dry_run:
         print('>> ' + command)
@@ -119,6 +124,12 @@ class CombineToolBase:
         self.custom_crab_post = None
         self.pre_cmd = ''
         self.crab_files = []
+        self.combine = None
+        self.combine_exec = 'combine'
+        self.cmssw_base = os.environ.get('CMSSW_BASE')
+        self.scram_arch = os.environ.get('SCRAM_ARCH')
+        self.standalone = False
+        self.job_prefix = _build_job_prefix(self.cmssw_base, self.scram_arch, self.standalone)
 
     def attach_job_args(self, group):
         group.add_argument('--job-mode', default=self.job_mode, choices=[
@@ -153,6 +164,8 @@ class CombineToolBase:
                            help='Postfix cmd for combine jobs [condor]')
         group.add_argument('--custom-crab-post', default=self.custom_crab_post,
                            help='txt file containing command lines that can be used in the crab job script instead of the defaults.')
+        group.add_argument('--combine', dest='combine',
+                           help='Path to the combine executable to use')
 
     def attach_intercept_args(self, group):
         pass
@@ -179,6 +192,16 @@ class CombineToolBase:
         self.pre_cmd = self.args.pre_cmd
         self.custom_crab_post = self.args.custom_crab_post
         self.post_job_cmd= self.args.post_job_cmd
+        self.combine = self.args.combine
+        found = shutil.which('combine')
+        if self.combine:
+            self.combine_exec = self.combine
+            self.standalone = True
+        elif found:
+            self.combine_exec = 'combine'
+            self.combine = found
+            self.standalone = True
+        self.job_prefix = _build_job_prefix(self.cmssw_base, self.scram_arch, self.standalone)
 
     def put_back_arg(self, arg_name, target_name):
         if hasattr(self.args, arg_name):
@@ -201,14 +224,16 @@ class CombineToolBase:
         fname = script_filename
         logname = script_filename.replace('.sh', '.log')
         with open(fname, "w") as text_file:
-            text_file.write(JOB_PREFIX)
+            text_file.write(self.job_prefix)
             for i, command in enumerate(commands):
                 tee = 'tee' if i == 0 else 'tee -a'
                 log_part = '\n'
                 if do_log: log_part = ' 2>&1 | %s ' % tee + logname + log_part
                 if command.startswith('combine') or command.startswith('pushd'):
-                    text_file.write(
-                        self.pre_cmd + 'eval ' + command + log_part)
+                    new_cmd = command
+                    if command.startswith('combine'):
+                        new_cmd = command.replace('combine', self.combine_exec, 1)
+                    text_file.write(self.pre_cmd + 'eval ' + new_cmd + log_part)
                 else:
                     text_file.write(command)
             text_file.write('\n'+self.post_job_cmd+'\n')
@@ -244,18 +269,17 @@ class CombineToolBase:
         if self.job_mode == 'interactive':
             pool = Pool(processes=self.parallel)
             result = pool.map(
-                partial(run_command, self.dry_run, pre_cmd=self.pre_cmd), self.job_queue)
+                partial(run_command, self.dry_run, pre_cmd=self.pre_cmd, combine_exec=self.combine_exec), self.job_queue)
         script_list = []
         if self.job_mode in ['script', 'lxbatch', 'SGE', 'slurm']:
             if self.prefix_file != '':
                 if self.prefix_file.endswith('.txt'):
                     job_prefix_file = open(self.prefix_file,'r')
                 else :
-                    job_prefix_file = open(os.environ['CMSSW_BASE']+"/src/CombineHarvester/CombineTools/input/job_prefixes/job_prefix_"+self.prefix_file+".txt",'r')
-                global JOB_PREFIX
-                JOB_PREFIX=job_prefix_file.read() %({
-                  'CMSSW_BASE': os.environ['CMSSW_BASE'],
-                  'SCRAM_ARCH': os.environ['SCRAM_ARCH'],
+                    job_prefix_file = open((self.cmssw_base or '')+"/src/CombineHarvester/CombineTools/input/job_prefixes/job_prefix_"+self.prefix_file+".txt",'r')
+                self.job_prefix = job_prefix_file.read() %({
+                  'CMSSW_BASE': self.cmssw_base or '',
+                  'SCRAM_ARCH': self.scram_arch or '',
                   'PWD': os.environ['PWD']
                 })
                 job_prefix_file.close()
@@ -304,14 +328,14 @@ class CombineToolBase:
             subfilename = 'condor_%s.sub' % self.task_name
             print('>> condor job script will be %s' % outscriptname)
             outscript = open(outscriptname, "w")
-            outscript.write(JOB_PREFIX)
+            outscript.write(self.job_prefix)
             jobs = 0
             wsp_files = set()
             for i, j in enumerate(range(0, len(self.job_queue), self.merge)):
                 outscript.write('\nif [ $1 -eq %i ]; then\n' % jobs)
                 jobs += 1
                 for line in self.job_queue[j:j + self.merge]:
-                    newline = self.pre_cmd + line
+                    newline = self.pre_cmd + line.replace('combine', self.combine_exec, 1)
                     outscript.write('  ' + newline + '\n')
                 outscript.write('fi')
             outscript.write('\n' + self.post_job_cmd+'\n')
@@ -347,7 +371,9 @@ class CombineToolBase:
                 outscript.write('\nif [ $1 -eq %i ]; then\n' % jobs)
                 for line in self.job_queue[j:j + self.merge]:
                     newline = line
-                    if line.startswith('combine'): newline = self.pre_cmd + line.replace('combine', './combine', 1)
+                    if line.startswith('combine'):
+                        repl = './combine' if not self.standalone else self.combine_exec
+                        newline = self.pre_cmd + line.replace('combine', repl, 1)
                     wsp = str(self.extract_workspace_arg(newline.split()))
 
                     newline = newline.replace(wsp, os.path.basename(wsp))
@@ -370,6 +396,8 @@ class CombineToolBase:
             else:
                 outscript.write(CRAB_POSTFIX)
             outscript.close()
+            if self.combine:
+                os.environ['COMBINE_PATH'] = self.combine
             from CombineHarvester.CombineTools.combine.crab import config
             config.General.requestName = self.task_name
             config.JobType.scriptExe = outscriptname
@@ -378,7 +406,8 @@ class CombineToolBase:
             config.Data.outputDatasetTag = config.General.requestName
             if self.memory is not None:
                 config.JobType.maxMemoryMB = self.memory
-            do_nothing_script = open(os.environ["CMSSW_BASE"]+"/src/CombineHarvester/CombineTools/scripts/do_nothing_cfg.py","w")
+            scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'scripts'))
+            do_nothing_script = open(os.path.join(scripts_dir, 'do_nothing_cfg.py'), "w")
             do_nothing_script.write(CRAB_DO_NOTHING)
             if self.cores is not None:
                 config.JobType.numCores = self.cores

--- a/CombineTools/python/combine/crab.py
+++ b/CombineTools/python/combine/crab.py
@@ -3,6 +3,11 @@ import os
 from WMCore.Configuration import Configuration
 
 
+cmssw_base = os.environ.get('CMSSW_BASE')
+scram_arch = os.environ.get('SCRAM_ARCH')
+combine_path = os.environ.get('COMBINE_PATH')
+scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'scripts'))
+
 config = Configuration()
 
 config.section_('General')
@@ -12,9 +17,17 @@ config.General.requestName = ''
 
 config.section_('JobType')
 config.JobType.pluginName = 'PrivateMC'
-config.JobType.psetName = os.environ['CMSSW_BASE']+'/src/CombineHarvester/CombineTools/scripts/do_nothing_cfg.py'
+config.JobType.psetName = os.path.join(scripts_dir, 'do_nothing_cfg.py')
 config.JobType.scriptExe = ''
-config.JobType.inputFiles = [os.environ['CMSSW_BASE']+'/src/CombineHarvester/CombineTools/scripts/FrameworkJobReport.xml', os.environ['CMSSW_BASE']+'/src/CombineHarvester/CombineTools/scripts/copyRemoteWorkspace.sh', os.environ['CMSSW_BASE']+'/bin/'+os.environ['SCRAM_ARCH']+'/combine']
+input_files = [
+    os.path.join(scripts_dir, 'FrameworkJobReport.xml'),
+    os.path.join(scripts_dir, 'copyRemoteWorkspace.sh')
+]
+if combine_path:
+    input_files.append(combine_path)
+elif cmssw_base and scram_arch:
+    input_files.append(os.path.join(cmssw_base, 'bin', scram_arch, 'combine'))
+config.JobType.inputFiles = input_files
 config.JobType.outputFiles = ['combine_output.tar']
 # config.JobType.maxMemoryMB = args.maxMemory
 


### PR DESCRIPTION
## Summary
- detect standalone combine and allow providing its path
- update job scripts to skip CMSSW setup when combine is standalone
- allow CRAB submissions without CMSSW

## Testing
- `python -m py_compile CombineTools/python/combine/CombineToolBase.py CombineTools/python/combine/crab.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba882a7e488329abaa9a0c225edcee