### PR TITLE
Add Python packaging and resource handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@
 output/
 
 # Python
-__init__.py
 *.pyc
 
 *.root

--- a/CombineHarvester/__init__.py
+++ b/CombineHarvester/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for CombineHarvester."""

--- a/CombineTools/input/__init__.py
+++ b/CombineTools/input/__init__.py
@@ -1,0 +1,1 @@
+"""Input data for CombineHarvester."""

--- a/CombineTools/input/examples/__init__.py
+++ b/CombineTools/input/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Example inputs for CombineHarvester."""

--- a/CombineTools/input/job_prefixes/__init__.py
+++ b/CombineTools/input/job_prefixes/__init__.py
@@ -1,0 +1,1 @@
+"""Job prefix templates for CombineHarvester."""

--- a/CombineTools/input/xsecs_brs/__init__.py
+++ b/CombineTools/input/xsecs_brs/__init__.py
@@ -1,0 +1,1 @@
+"""Cross sections and branching ratios for CombineHarvester."""

--- a/CombineTools/python/__init__.py
+++ b/CombineTools/python/__init__.py
@@ -1,0 +1,1 @@
+"""Python utilities for CombineHarvester."""

--- a/CombineTools/python/combine/__init__.py
+++ b/CombineTools/python/combine/__init__.py
@@ -1,0 +1,1 @@
+"""Command line helper tools for CombineHarvester."""

--- a/CombineTools/python/combine/crab.py
+++ b/CombineTools/python/combine/crab.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 import os
+from pathlib import Path
+from importlib import resources
 from WMCore.Configuration import Configuration
 
 
@@ -12,9 +14,14 @@ config.General.requestName = ''
 
 config.section_('JobType')
 config.JobType.pluginName = 'PrivateMC'
-config.JobType.psetName = os.environ['CMSSW_BASE']+'/src/CombineHarvester/CombineTools/scripts/do_nothing_cfg.py'
+config.JobType.psetName = str(Path('do_nothing_cfg.py'))
+scripts = resources.files('CombineHarvester.CombineTools.scripts')
 config.JobType.scriptExe = ''
-config.JobType.inputFiles = [os.environ['CMSSW_BASE']+'/src/CombineHarvester/CombineTools/scripts/FrameworkJobReport.xml', os.environ['CMSSW_BASE']+'/src/CombineHarvester/CombineTools/scripts/copyRemoteWorkspace.sh', os.environ['CMSSW_BASE']+'/bin/'+os.environ['SCRAM_ARCH']+'/combine']
+config.JobType.inputFiles = [
+    str(scripts / 'FrameworkJobReport.xml'),
+    str(scripts / 'copyRemoteWorkspace.sh'),
+    os.environ['CMSSW_BASE']+'/bin/'+os.environ['SCRAM_ARCH']+'/combine'
+]
 config.JobType.outputFiles = ['combine_output.tar']
 # config.JobType.maxMemoryMB = args.maxMemory
 

--- a/CombineTools/python/maketable.py
+++ b/CombineTools/python/maketable.py
@@ -86,3 +86,20 @@ def TablefromJson(jsonfile, filename):
         f.write("\n")
         i+=1
     f.close()
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(
+        description="Convert combine output to a text table.")
+    parser.add_argument("input", help="Input file (ROOT or JSON)")
+    parser.add_argument("output", help="Output text file")
+    args = parser.parse_args()
+    if args.input.endswith('.json'):
+        TablefromJson(args.input, args.output)
+    else:
+        Tablefrom1DGraph(args.input, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/CombineTools/python/pdgRounding.py
+++ b/CombineTools/python/pdgRounding.py
@@ -13,6 +13,8 @@
 # September 2012
 
 from __future__ import print_function
+import argparse
+
 def pdgRound(value, error) :
     "Given a value and an error, round and format them according to the PDG rules for significant digits"
     def threeDigits(value) :
@@ -50,6 +52,14 @@ def test(valueError=(0., 0.)) :
     val, err = pdgRound(val, err)
     print(' ',val,' +/- ',err)
 
+def main():
+    parser = argparse.ArgumentParser(
+        description="Round a value and uncertainty using PDG rules.")
+    parser.add_argument("value", type=float, help="Central value")
+    parser.add_argument("error", type=float, help="Uncertainty on the value")
+    args = parser.parse_args()
+    val, err = pdgRound(args.value, args.error)
+    print(f"{val} +/- {err}")
+
 if __name__=='__main__' :
-    for x in [(26710, 177)
-                ] : test(x)
+    main()

--- a/CombineTools/python/systematics/__init__.py
+++ b/CombineTools/python/systematics/__init__.py
@@ -1,0 +1,1 @@
+"""Systematics modules for CombineHarvester."""

--- a/CombineTools/scripts/SMLegacyExample.py
+++ b/CombineTools/scripts/SMLegacyExample.py
@@ -7,13 +7,14 @@ import CombineHarvester.CombineTools.systematics.SMLegacy as SMLegacySysts
 import ROOT as R
 import glob
 import os
+from importlib import resources
 
 cb = ch.CombineHarvester()
 
 auxiliaries  = os.environ['CMSSW_BASE'] + '/src/auxiliaries/'
 aux_shapes   = auxiliaries +'shapes/'
 aux_pruning  = auxiliaries +'pruning/'
-input_dir    = os.environ['CMSSW_BASE'] + '/src/CombineHarvester/CombineTools/input';
+input_dir = resources.files('CombineHarvester.CombineTools.input')
 
 chns = ['et', 'mt', 'em', 'ee', 'mm', 'tt']
 
@@ -119,17 +120,17 @@ for era in ['7TeV', '8TeV']:
 print('>> Scaling signal process rates...')
 xs = { }
 # Get the table of H->tau tau BRs vs mass
-xs['htt'] = ch.TGraphFromTable(input_dir+'/xsecs_brs/htt_YR3.txt', 'mH', 'br')
+xs['htt'] = ch.TGraphFromTable(str(input_dir / 'xsecs_brs' / 'htt_YR3.txt'), 'mH', 'br')
 for e in ['7TeV', '8TeV']:
     for p in sig_procs:
         # Get the table of xsecs vs mass for process 'p' and era 'e':
-        xs[p+'_'+e] = ch.TGraphFromTable(input_dir+'/xsecs_brs/'+p+'_'+e+'_YR3.txt', 'mH', 'xsec')
+        xs[p+'_'+e] = ch.TGraphFromTable(str(input_dir / 'xsecs_brs' / (p+'_'+e+'_YR3.txt')), 'mH', 'xsec')
         print('>>>> Scaling for process ' + p + ' and era ' + e)
         cb.cp().process([p]).era([e]).ForEachProc(
           lambda x : x.set_rate(
             x.rate() * xs[p+'_'+e].Eval(float(x.mass())) * xs['htt'].Eval(float(x.mass())))
         )
-xs['hww_over_htt'] = ch.TGraphFromTable(input_dir+'/xsecs_brs/hww_over_htt.txt', 'mH', 'ratio')
+xs['hww_over_htt'] = ch.TGraphFromTable(str(input_dir / 'xsecs_brs' / 'hww_over_htt.txt'), 'mH', 'ratio')
 
 for e in ['7TeV', '8TeV']:
     for p in sig_procs:

--- a/CombineTools/scripts/__init__.py
+++ b/CombineTools/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Auxiliary scripts for CombineHarvester."""

--- a/README.md
+++ b/README.md
@@ -18,3 +18,24 @@ A new full release area can be set up and compiled in the following steps:
     scram b
 
 Previously this package contained some analysis-specific subpackages. These packages can now be found [here](https://gitlab.cern.ch/cms-hcg/ch-areas). If you would like a repository for your analysis package to be created in that group, please create an issue in the CombineHarvester repository stating the desired package name and your NICE username. Note: you are not obliged to store your analysis package in this central group.
+
+## Python package
+
+The CombineHarvester Python utilities can be installed with
+
+```
+pip install .
+```
+
+This installs the `CombineHarvester` package together with the compiled
+`libCombineHarvesterCombineTools` bindings and the `pdg-round` and
+`ch-maketable` command line tools.  After installing, resources shipped
+with the package are accessed via `importlib.resources` so no manual path
+configuration is required.
+
+### Example
+
+```
+pdg-round 26710 177
+ch-maketable limits.json table.txt
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "combineharvester"
+version = "0.1.0"
+description = "CMS CombineHarvester tools"
+readme = "README.md"
+authors = [{name = "CMS"}]
+requires-python = ">=3.8"
+
+[project.scripts]
+pdg-round = "CombineHarvester.CombineTools.pdgRounding:main"
+ch-maketable = "CombineHarvester.CombineTools.maketable:main"
+
+[tool.setuptools]
+packages = [
+    "CombineHarvester",
+    "CombineHarvester.CombineTools",
+    "CombineHarvester.CombineTools.combine",
+    "CombineHarvester.CombineTools.systematics",
+    "CombineHarvester.CombineTools.scripts",
+    "CombineHarvester.CombineTools.input",
+    "CombineHarvester.CombineTools.input.examples",
+    "CombineHarvester.CombineTools.input.job_prefixes",
+    "CombineHarvester.CombineTools.input.xsecs_brs",
+]
+package-dir = {
+    "CombineHarvester": "CombineHarvester",
+    "CombineHarvester.CombineTools": "CombineTools/python",
+    "CombineHarvester.CombineTools.combine": "CombineTools/python/combine",
+    "CombineHarvester.CombineTools.systematics": "CombineTools/python/systematics",
+    "CombineHarvester.CombineTools.scripts": "CombineTools/scripts",
+    "CombineHarvester.CombineTools.input": "CombineTools/input",
+    "CombineHarvester.CombineTools.input.examples": "CombineTools/input/examples",
+    "CombineHarvester.CombineTools.input.job_prefixes": "CombineTools/input/job_prefixes",
+    "CombineHarvester.CombineTools.input.xsecs_brs": "CombineTools/input/xsecs_brs",
+}
+
+[tool.setuptools.package-data]
+"CombineHarvester.CombineTools" = ["*.so"]
+"CombineHarvester.CombineTools.scripts" = ["*"]
+"CombineHarvester.CombineTools.input" = ["*"]
+"CombineHarvester.CombineTools.input.examples" = ["*"]
+"CombineHarvester.CombineTools.input.job_prefixes" = ["*"]
+"CombineHarvester.CombineTools.input.xsecs_brs" = ["*"]


### PR DESCRIPTION
## Summary
- add `pyproject.toml` packaging metadata with console entry points
- switch helper modules to load data via `importlib.resources`
- include C++ bindings in package data and document pip installation

## Testing
- `python -m compileall CombineHarvester CombineTools/python CombineTools/scripts CombineTools/input`
- `python CombineTools/python/pdgRounding.py 26710 177`
- `PYTHONPATH=. python CombineTools/python/maketable.py --help` *(fails: No module named 'CombineHarvester.CombineTools')*
- `ln -s ../CombineTools/python CombineHarvester/CombineTools && PYTHONPATH=. python CombineTools/python/maketable.py --help` *(fails: No module named 'ROOT')*

------
https://chatgpt.com/codex/tasks/task_e_68ba883365e083299ad7f0fa87337930