### PR TITLE
Add external dependencies and install targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,31 @@ else()
   set(HiggsAnalysisCombinedLimit_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/HiggsAnalysis/CombinedLimit/interface)
 endif()
 
+find_package(ROOT REQUIRED COMPONENTS RooFit RooStats)
+find_package(Boost REQUIRED)
+find_package(LibXml2 REQUIRED)
+find_package(vdt REQUIRED)
+find_package(HistFactory REQUIRED)
+
+set(CH_EXTERNAL_INCLUDES
+  ${ROOT_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
+  ${LIBXML2_INCLUDE_DIR}
+  ${vdt_INCLUDE_DIRS}
+  ${HistFactory_INCLUDE_DIRS}
+)
+
+set(CH_EXTERNAL_LIBS
+  ${ROOT_LIBRARIES}
+  ${Boost_LIBRARIES}
+  ${LIBXML2_LIBRARIES}
+  ${vdt_LIBRARIES}
+  ${HistFactory_LIBRARIES}
+)
+
+add_subdirectory(CombineTools)
+add_subdirectory(CombinePdfs)
+
 add_library(CombineHarvester INTERFACE)
 target_include_directories(CombineHarvester INTERFACE
   ${CMAKE_CURRENT_SOURCE_DIR}/CombineTools/interface
@@ -23,8 +48,14 @@ target_include_directories(CombineHarvester INTERFACE
   ${HiggsAnalysisCombinedLimit_INCLUDE_DIRS}
 )
 
-target_link_libraries(CombineHarvester INTERFACE ${HiggsAnalysisCombinedLimit_LIBRARIES})
+target_link_libraries(CombineHarvester INTERFACE CombineTools CombinePdfs ${HiggsAnalysisCombinedLimit_LIBRARIES})
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/HiggsAnalysis/CombinedLimit/interface/
         DESTINATION include/HiggsAnalysis/CombinedLimit
         FILES_MATCHING PATTERN "*.h" PATTERN "*.hh")
+
+install(TARGETS CombineHarvester EXPORT CombineHarvesterTargets)
+install(EXPORT CombineHarvesterTargets
+        FILE CombineHarvesterTargets.cmake
+        NAMESPACE CombineHarvester::
+        DESTINATION lib/cmake/CombineHarvester)

--- a/CombinePdfs/CMakeLists.txt
+++ b/CombinePdfs/CMakeLists.txt
@@ -6,8 +6,16 @@ target_include_directories(CombinePdfs PUBLIC interface ${CH_EXTERNAL_INCLUDES})
 target_link_libraries(CombinePdfs PUBLIC CombineTools ${CH_EXTERNAL_LIBS})
 
 file(GLOB COMBINE_PDFS_BINS bin/*.cpp)
+set(COMBINE_PDFS_BINARIES)
 foreach(src ${COMBINE_PDFS_BINS})
   get_filename_component(name ${src} NAME_WE)
   add_executable(${name} ${src})
   target_link_libraries(${name} CombinePdfs)
+  list(APPEND COMBINE_PDFS_BINARIES ${name})
 endforeach()
+
+install(TARGETS CombinePdfs ${COMBINE_PDFS_BINARIES}
+  EXPORT CombineHarvesterTargets
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib)

--- a/CombineTools/CMakeLists.txt
+++ b/CombineTools/CMakeLists.txt
@@ -6,8 +6,16 @@ target_include_directories(CombineTools PUBLIC interface ${CH_EXTERNAL_INCLUDES}
 target_link_libraries(CombineTools PUBLIC ${CH_EXTERNAL_LIBS})
 
 file(GLOB COMBINE_TOOLS_BINS bin/*.cpp)
+set(COMBINE_TOOLS_BINARIES)
 foreach(src ${COMBINE_TOOLS_BINS})
   get_filename_component(name ${src} NAME_WE)
   add_executable(${name} ${src})
   target_link_libraries(${name} CombineTools)
+  list(APPEND COMBINE_TOOLS_BINARIES ${name})
 endforeach()
+
+install(TARGETS CombineTools ${COMBINE_TOOLS_BINARIES}
+  EXPORT CombineHarvesterTargets
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib)


### PR DESCRIPTION
## Summary
- Discover ROOT, Boost, libxml2, vdt, and HistFactory and propagate their include paths and libraries
- Build CombineTools and CombinePdfs subdirectories and link them into CombineHarvester
- Export and install CombineHarvester along with CombineTools, CombinePdfs, and example binaries

## Testing
- `cmake -S . -B build` *(fails: HiggsAnalysis/CombinedLimit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8c3ce6e483299a41cd934f2fd05a