### PR TITLE
feat: allow configurable auxiliaries path

### DIFF
--- a/CombineTools/interface/PathTools.h
+++ b/CombineTools/interface/PathTools.h
@@ -9,7 +9,8 @@ namespace paths {
 // discover the location by searching upwards from the current directory.
 std::string base();
 
-// Path to the external auxiliaries directory.
+// Path to the external auxiliaries directory. Can be overridden by the
+// CH_AUXILIARIES environment variable.
 std::string auxiliaries();
 
 // Path to the CombineTools input directory.

--- a/CombineTools/scripts/HhhExample.py
+++ b/CombineTools/scripts/HhhExample.py
@@ -10,8 +10,9 @@ import os
 
 cb = ch.CombineHarvester()
 
-auxiliaries  = os.environ['CMSSW_BASE'] + '/src/auxiliaries/'
-aux_shapes   = auxiliaries +'shapes/'
+ch_base = os.environ.get('CH_BASE', os.environ.get('CMSSW_BASE', '') + '/src/CombineHarvester')
+auxiliaries  = os.environ.get('CH_AUXILIARIES', ch_base + '/auxiliaries/')
+aux_shapes   = auxiliaries + 'shapes/'
 
 chns = ['et', 'mt', 'tt']
 

--- a/CombineTools/scripts/SMLegacyExample.py
+++ b/CombineTools/scripts/SMLegacyExample.py
@@ -11,9 +11,10 @@ from importlib import resources
 
 cb = ch.CombineHarvester()
 
-auxiliaries  = os.environ['CMSSW_BASE'] + '/src/auxiliaries/'
-aux_shapes   = auxiliaries +'shapes/'
-aux_pruning  = auxiliaries +'pruning/'
+ch_base = os.environ.get('CH_BASE', os.environ.get('CMSSW_BASE', '') + '/src/CombineHarvester')
+auxiliaries  = os.environ.get('CH_AUXILIARIES', ch_base + '/auxiliaries/')
+aux_shapes   = auxiliaries + 'shapes/'
+aux_pruning  = auxiliaries + 'pruning/'
 input_dir = resources.files('CombineHarvester.CombineTools.input')
 
 chns = ['et', 'mt', 'em', 'ee', 'mm', 'tt']

--- a/CombineTools/scripts/setup-tH.py
+++ b/CombineTools/scripts/setup-tH.py
@@ -7,8 +7,9 @@ import os
 
 cb = ch.CombineHarvester()
 
-auxiliaries  = os.environ['CMSSW_BASE'] + '/src/auxiliaries/'
-aux_shapes   = auxiliaries +'shapes/'
+ch_base = os.environ.get('CH_BASE', os.environ.get('CMSSW_BASE', '') + '/src/CombineHarvester')
+auxiliaries  = os.environ.get('CH_AUXILIARIES', ch_base + '/auxiliaries/')
+aux_shapes   = auxiliaries + 'shapes/'
 
 procs = {
   'sig'  : ['tH_YtMinus', 'tHW'],

--- a/CombineTools/src/PathTools.cc
+++ b/CombineTools/src/PathTools.cc
@@ -25,7 +25,9 @@ std::string base() {
 }
 
 std::string auxiliaries() {
-  return base() + "/../auxiliaries/";
+  const char* env = std::getenv("CH_AUXILIARIES");
+  if (env) return std::string(env);
+  return base() + "/auxiliaries/";
 }
 
 std::string input() {

--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ Set the `CH_BASE` environment variable to the location of the repository (or ins
 export CH_BASE=$(pwd)
 ```
 
-Some examples require auxiliary ROOT files. These can be obtained from the [HiggsAnalysis-HiggsToTauTau-auxiliaries](https://github.com/roger-wolf/HiggsAnalysis-HiggsToTauTau-auxiliaries) repository:
+Some examples require auxiliary ROOT files. These can be obtained from the
+[HiggsAnalysis-HiggsToTauTau-auxiliaries](https://github.com/roger-wolf/HiggsAnalysis-HiggsToTauTau-auxiliaries)
+repository. By default these files are expected in `$CH_BASE/auxiliaries/`.
+This location can be overridden by setting the `CH_AUXILIARIES` environment
+variable:
 
 ```
 git clone https://github.com/roger-wolf/HiggsAnalysis-HiggsToTauTau-auxiliaries.git "$CH_BASE/auxiliaries"


### PR DESCRIPTION
## Summary
- resolve auxiliaries path inside repository by default
- allow custom `CH_AUXILIARIES` override and update example scripts
- document new path behaviour in README

## Testing
- `python -m pytest -c /dev/null`
- `cmake -S . -B build` *(fails: HiggsAnalysis/CombinedLimit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8c3dd8908329abc26f5f08fc0111