### PR TITLE
Add standalone option and robust env handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ No CMSSW environment is required for these commands.
 
 For backward support the previous CMSSW-based workflow remains available. The framework is compatible with the CMSSW 14_1_X and 11_3_X series releases and can still be placed in a CMSSW release area together with `HiggsAnalysis/CombinedLimit` and compiled with `scram b` following the recommendations of the combine developers.
 
+When running the python utilities such as `combineTool.py` outside of a
+CMSSW release, the `--standalone` option can be used to bypass the CMSSW
+environment setup in generated job scripts.
+
 Previously this package contained some analysis-specific subpackages. These packages can now be found [here](https://gitlab.cern.ch/cms-hcg/ch-areas). If you would like a repository for your analysis package to be created in that group, please create an issue in the CombineHarvester repository stating the desired package name and your NICE username. Note: you are not obliged to store your analysis package in this central group.
 
 ## Python package


### PR DESCRIPTION
## Summary
- allow job tools to run in standalone mode via new `--standalone` flag
- use safe environment lookups with sensible defaults
- document standalone job behaviour

## Testing
- `pytest` *(fails: Invalid initial character for a key part)*
- `python -m py_compile CombineTools/python/combine/CombineToolBase.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba8c3f63f48329bcc5724cb9513401