### PR TITLE
Allow custom combine executable for CRAB jobs

### DIFF
--- a/CombineTools/python/combine/CombineToolBase.py
+++ b/CombineTools/python/combine/CombineToolBase.py
@@ -400,9 +400,8 @@ class CombineToolBase:
             else:
                 outscript.write(CRAB_POSTFIX)
             outscript.close()
-            if self.combine:
-                os.environ['COMBINE_PATH'] = self.combine
-            from CombineHarvester.CombineTools.combine.crab import config
+            from CombineHarvester.CombineTools.combine.crab import create_crab_config
+            config = create_crab_config(self.combine)
             config.General.requestName = self.task_name
             config.JobType.scriptExe = outscriptname
             config.JobType.inputFiles.extend(wsp_files)

--- a/CombineTools/python/combine/crab.py
+++ b/CombineTools/python/combine/crab.py
@@ -1,45 +1,85 @@
+"""CRAB configuration used by CombineTool.
+
+This module builds and returns a :class:`WMCore.Configuration.Configuration`
+object for submitting combine jobs with CRAB.  The CRAB client is part of the
+CMS software (CMSSW) distribution, therefore this module must be used from
+within a CMSSW environment where :mod:`WMCore` is available.
+
+The combine executable can be provided either via the ``COMBINE_PATH``
+environment variable or passed explicitly to :func:`create_crab_config`.
+If the executable cannot be located it will not be added to the list of files
+sent with the job and a warning will be emitted.
+"""
+
 from __future__ import absolute_import
+
 import os
+import warnings
 from pathlib import Path
 from importlib import resources
-from WMCore.Configuration import Configuration
+
+try:
+    from WMCore.Configuration import Configuration
+except ImportError as exc:  # pragma: no cover - user environment issue
+    raise ImportError(
+        "WMCore is required to create CRAB configurations. "
+        "Ensure that a CMSSW environment is active."
+    ) from exc
 
 
-cmssw_base = os.environ.get('CMSSW_BASE')
-scram_arch = os.environ.get('SCRAM_ARCH')
-combine_path = os.environ.get('COMBINE_PATH')
-scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'scripts'))
+def create_crab_config(combine_executable=None):
+    """Create and return a CRAB :class:`Configuration` instance.
 
-config = Configuration()
+    Parameters
+    ----------
+    combine_executable:
+        Optional path to the ``combine`` executable. If not supplied, the
+        ``COMBINE_PATH`` environment variable is consulted.
+    """
 
-config.section_('General')
-config.General.requestName = ''
-# if (args.workArea != ''):
-#   config.General.workArea = args.workArea
+    combine_path = combine_executable or os.environ.get("COMBINE_PATH")
+    scripts = resources.files('CombineHarvester.CombineTools.scripts')
 
-config.section_('JobType')
-config.JobType.pluginName = 'PrivateMC'
-config.JobType.psetName = str(Path('do_nothing_cfg.py'))
-scripts = resources.files('CombineHarvester.CombineTools.scripts')
-config.JobType.scriptExe = ''
-config.JobType.inputFiles = [
-    str(scripts / 'FrameworkJobReport.xml'),
-    str(scripts / 'copyRemoteWorkspace.sh'),
-    os.environ['CMSSW_BASE']+'/bin/'+os.environ['SCRAM_ARCH']+'/combine'
-]
-config.JobType.outputFiles = ['combine_output.tar']
-# config.JobType.maxMemoryMB = args.maxMemory
+    config = Configuration()
 
-config.section_('Data')
-config.Data.outputPrimaryDataset = 'Combine'
-config.Data.splitting = 'EventBased'
-config.Data.unitsPerJob = 1
-config.Data.totalUnits = 1
-config.Data.publication = False
-config.Data.outputDatasetTag = ''
+    config.section_('General')
+    config.General.requestName = ''
 
-config.section_('User')
+    config.section_('JobType')
+    config.JobType.pluginName = 'PrivateMC'
+    config.JobType.psetName = str(Path('do_nothing_cfg.py'))
+    config.JobType.scriptExe = ''
+    config.JobType.inputFiles = [
+        str(scripts / 'FrameworkJobReport.xml'),
+        str(scripts / 'copyRemoteWorkspace.sh'),
+    ]
+    if combine_path and os.path.exists(combine_path):
+        config.JobType.inputFiles.append(combine_path)
+    else:
+        warnings.warn(
+            'combine executable not found; set COMBINE_PATH or pass the '
+            'path to create_crab_config()',
+            RuntimeWarning
+        )
+    config.JobType.outputFiles = ['combine_output.tar']
 
-config.section_('Site')
-config.Site.blacklist = ['T3_IT_Bologna','T3_US_UMiss']
-config.Site.storageSite = 'T2_CH_CERN'
+    config.section_('Data')
+    config.Data.outputPrimaryDataset = 'Combine'
+    config.Data.splitting = 'EventBased'
+    config.Data.unitsPerJob = 1
+    config.Data.totalUnits = 1
+    config.Data.publication = False
+    config.Data.outputDatasetTag = ''
+
+    config.section_('User')
+
+    config.section_('Site')
+    config.Site.blacklist = ['T3_IT_Bologna', 'T3_US_UMiss']
+    config.Site.storageSite = 'T2_CH_CERN'
+
+    return config
+
+
+# For backward compatibility with existing imports
+config = create_crab_config()
+

--- a/CombineTools/scripts/do_nothing_cfg.py
+++ b/CombineTools/scripts/do_nothing_cfg.py
@@ -1,5 +1,12 @@
 from __future__ import absolute_import
-import FWCore.ParameterSet.Config as cms
+
+try:
+    import FWCore.ParameterSet.Config as cms
+except ImportError as exc:  # pragma: no cover - runtime environment
+    raise ImportError(
+        "FWCore is required to run this configuration. "
+        "Ensure that a CMSSW environment is active."
+    ) from exc
 process = cms.Process("MAIN")
 
 process.source = cms.Source("EmptySource")


### PR DESCRIPTION
## Summary
- handle missing WMCore and FWCore imports more gracefully
- support passing combine executable path via COMBINE_PATH or function argument
- warn when combine executable can't be found for CRAB jobs
- document the CMSSW requirement for CRAB usage

## Testing
- `pytest` *(fails: Invalid initial character for a key part (at line 29, column 16))*
- `python -m py_compile CombineTools/python/combine/crab.py CombineTools/scripts/do_nothing_cfg.py CombineTools/python/combine/CombineToolBase.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba8c40e2608329a6f15a88b4047e23