### PR TITLE
Replace CMSSW_BASE with CH_BASE path helpers

### DIFF
--- a/CombinePdfs/python/ModelIndependent.py
+++ b/CombinePdfs/python/ModelIndependent.py
@@ -114,7 +114,9 @@ class FloatingMSSMXSHiggs(MSSMLikeHiggsModel):
         ## the values are given by the value in brakets. In principle three values can be passed on: value, lower bound and upper
         ## bound.
         #
-        #mssm_scan = mssm_xsec_tools("{CMSSW_BASE}/src/{PATH}".format(CMSSW_BASE=os.environ['CMSSW_BASE'], PATH="HiggsAnalysis/HiggsToTauTau/data/out.mhmax-mu+200-7TeV-nnlo.root"))
+        #mssm_scan = mssm_xsec_tools(
+        #    "{CH_BASE}/src/{PATH}".format(CH_BASE=os.environ.get('CH_BASE', ''),
+        #                                 PATH="HiggsAnalysis/HiggsToTauTau/data/out.mhmax-mu+200-7TeV-nnlo.root"))
         #mssm_xsec = mssm_scan.query(self.options.mass, float(self.tanb))
         #self.modelBuilder.doVar("bbH_xsec[%g]" % (mssm_xsec['higgses']['A']['xsec']['santander']*mssm_xsec['higgses']['A']['BR']))
         #self.modelBuilder.doVar("ggH_xsec[%g]" % (mssm_xsec['higgses']['A']['xsec']['ggF'      ]*mssm_xsec['higgses']['A']['BR']))

--- a/CombineTools/python/combine/CombineToolBase.py
+++ b/CombineTools/python/combine/CombineToolBase.py
@@ -7,6 +7,7 @@ from functools import partial
 from multiprocessing import Pool
 from six.moves import range
 from importlib import resources
+import CombineHarvester.CombineTools.ch as ch
 
 DRY_RUN = False
 
@@ -127,7 +128,7 @@ class CombineToolBase:
         self.crab_files = []
         self.combine = None
         self.combine_exec = 'combine'
-        self.cmssw_base = os.environ.get('CMSSW_BASE')
+        self.cmssw_base = os.environ.get('CH_BASE', ch.paths.base())
         self.scram_arch = os.environ.get('SCRAM_ARCH')
         self.standalone = False
         self.job_prefix = _build_job_prefix(self.cmssw_base, self.scram_arch, self.standalone)
@@ -281,9 +282,9 @@ class CombineToolBase:
                     path = resources.files(job_pkg).joinpath(f"job_prefix_{self.prefix_file}.txt")
                     job_prefix_file = path.open('r')
                 global JOB_PREFIX
-                JOB_PREFIX=job_prefix_file.read() %({
-                  'CMSSW_BASE': os.environ['CMSSW_BASE'],
-                  'SCRAM_ARCH': os.environ['SCRAM_ARCH'],
+                JOB_PREFIX = job_prefix_file.read() %({
+                  'CMSSW_BASE': ch.paths.base(),
+                  'SCRAM_ARCH': os.environ.get('SCRAM_ARCH', ''),
                   'PWD': os.environ['PWD']
                 })
                 job_prefix_file.close()

--- a/CombineTools/python/combine/crab.py
+++ b/CombineTools/python/combine/crab.py
@@ -4,8 +4,9 @@ from pathlib import Path
 from importlib import resources
 from WMCore.Configuration import Configuration
 
-
-cmssw_base = os.environ.get('CMSSW_BASE')
+# Prefer the CH_BASE environment variable to locate the combine executable,
+# falling back to a relative search if it is not set.
+ch_base = os.environ.get('CH_BASE')
 scram_arch = os.environ.get('SCRAM_ARCH')
 combine_path = os.environ.get('COMBINE_PATH')
 scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'scripts'))
@@ -25,7 +26,7 @@ config.JobType.scriptExe = ''
 config.JobType.inputFiles = [
     str(scripts / 'FrameworkJobReport.xml'),
     str(scripts / 'copyRemoteWorkspace.sh'),
-    os.environ['CMSSW_BASE']+'/bin/'+os.environ['SCRAM_ARCH']+'/combine'
+    os.path.join(ch_base or '', 'bin', scram_arch or '', 'combine')
 ]
 config.JobType.outputFiles = ['combine_output.tar']
 # config.JobType.maxMemoryMB = args.maxMemory

--- a/CombineTools/scripts/HhhExample.py
+++ b/CombineTools/scripts/HhhExample.py
@@ -10,8 +10,10 @@ import os
 
 cb = ch.CombineHarvester()
 
-auxiliaries  = os.environ['CMSSW_BASE'] + '/src/auxiliaries/'
-aux_shapes   = auxiliaries +'shapes/'
+# Use the CombineHarvester path helpers to locate the external auxiliaries
+# repository instead of relying on CMSSW specific environment variables.
+auxiliaries = ch.paths.auxiliaries()
+aux_shapes = os.path.join(auxiliaries, 'shapes')
 
 chns = ['et', 'mt', 'tt']
 

--- a/CombineTools/scripts/SMLegacyExample.py
+++ b/CombineTools/scripts/SMLegacyExample.py
@@ -11,9 +11,12 @@ from importlib import resources
 
 cb = ch.CombineHarvester()
 
-auxiliaries  = os.environ['CMSSW_BASE'] + '/src/auxiliaries/'
-aux_shapes   = auxiliaries +'shapes/'
-aux_pruning  = auxiliaries +'pruning/'
+# Locate the external auxiliaries repository via CH_BASE or by searching
+# upwards from the current directory. This removes the dependency on a
+# CMSSW environment.
+auxiliaries = ch.paths.auxiliaries()
+aux_shapes = os.path.join(auxiliaries, 'shapes')
+aux_pruning = os.path.join(auxiliaries, 'pruning')
 input_dir = resources.files('CombineHarvester.CombineTools.input')
 
 chns = ['et', 'mt', 'em', 'ee', 'mm', 'tt']

--- a/CombineTools/scripts/setup-tH.py
+++ b/CombineTools/scripts/setup-tH.py
@@ -7,8 +7,10 @@ import os
 
 cb = ch.CombineHarvester()
 
-auxiliaries  = os.environ['CMSSW_BASE'] + '/src/auxiliaries/'
-aux_shapes   = auxiliaries +'shapes/'
+# Resolve the location of the external auxiliaries repository using CH_BASE
+# or by searching relative to this file. This avoids reliance on CMSSW.
+auxiliaries = ch.paths.auxiliaries()
+aux_shapes = os.path.join(auxiliaries, 'shapes')
 
 procs = {
   'sig'  : ['tH_YtMinus', 'tHW'],


### PR DESCRIPTION
## Summary
- replace `CMSSW_BASE` lookups with `ch.paths` helpers across scripts
- document new path resolution and use `importlib.resources` where applicable

## Testing
- `python -m py_compile CombineTools/scripts/SMLegacyExample.py CombineTools/scripts/setup-tH.py CombineTools/scripts/HhhExample.py CombineTools/python/combine/crab.py CombineTools/python/combine/CombineToolBase.py CombinePdfs/python/ModelIndependent.py`
- `PYTHONPATH=. python CombineTools/scripts/SMLegacyExample.py` *(fails: ModuleNotFoundError: No module named 'cppyy')*
- `pip install cppyy` *(fails: Could not find a version that satisfies the requirement cppyy)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8c4481f483299b22616d9b672cf3