### PR TITLE
Use CH_BASE for Doxygen include path

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -161,7 +161,7 @@ STRIP_FROM_PATH        =
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    = $(CMSSW_BASE)/src
+STRIP_FROM_INC_PATH    = $(CH_BASE)
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't

--- a/docs/make_docs.sh
+++ b/docs/make_docs.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 
+export CH_BASE=$(git rev-parse --show-toplevel)
 doxygen Doxyfile
 # We need a custom page resize function
 # because of the modifications to the


### PR DESCRIPTION
## Summary
- configure Doxygen to strip headers relative to `CH_BASE`
- export `CH_BASE` before running Doxygen in documentation script

## Testing
- `./docs/make_docs.sh` *(fails: doxygen: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `pytest` *(fails: Invalid initial character for a key part)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9ce356c083298f8e89d6db9f2b28