### PR TITLE
Support CH_BASE placeholder in job prefixes

### DIFF
--- a/CombineTools/input/job_prefixes/job_prefix_ic.txt
+++ b/CombineTools/input/job_prefixes/job_prefix_ic.txt
@@ -1,6 +1,6 @@
 #!/bin/sh
 ulimit -s unlimited
-cd %(CMSSW_BASE)s/src
+cd %(CH_BASE)s
 export SCRAM_ARCH=%(SCRAM_ARCH)s
 source /vols/grid/cms/setup.sh
 eval `scramv1 runtime -sh`

--- a/CombineTools/input/job_prefixes/job_prefix_naf.txt
+++ b/CombineTools/input/job_prefixes/job_prefix_naf.txt
@@ -1,6 +1,6 @@
 #!/bin/sh
 ulimit -s unlimited
-cd %(CMSSW_BASE)s/src
+cd %(CH_BASE)s
 linux_ver=`lsb_release -s -r`
 echo $linux_ver
 if [[ $linux_ver < 6.0 ]];

--- a/CombineTools/python/combine/CombineToolBase.py
+++ b/CombineTools/python/combine/CombineToolBase.py
@@ -130,6 +130,12 @@ class CombineToolBase:
         self.cmssw_base = os.environ.get('CMSSW_BASE')
         self.scram_arch = os.environ.get('SCRAM_ARCH')
         self.standalone = False
+        self.ch_base = os.environ.get('CH_BASE')
+        if not self.ch_base:
+            if self.cmssw_base:
+                self.ch_base = os.path.join(self.cmssw_base, 'src')
+            else:
+                self.ch_base = os.getcwd()
         self.job_prefix = _build_job_prefix(self.cmssw_base, self.scram_arch, self.standalone)
 
     def attach_job_args(self, group):
@@ -284,9 +290,10 @@ class CombineToolBase:
                     path = resources.files(job_pkg).joinpath(f"job_prefix_{self.prefix_file}.txt")
                     job_prefix_file = path.open('r')
                 env = {
-                    'CMSSW_BASE': os.environ.get('CMSSW_BASE', ''),
+                    'CMSSW_BASE': self.cmssw_base or '',
                     'SCRAM_ARCH': os.environ.get('SCRAM_ARCH', ''),
-                    'PWD': os.environ.get('PWD', os.getcwd())
+                    'PWD': os.environ.get('PWD', os.getcwd()),
+                    'CH_BASE': self.ch_base
                 }
                 self.job_prefix = job_prefix_file.read() % env
                 job_prefix_file.close()

--- a/docs/Example1.md
+++ b/docs/Example1.md
@@ -15,6 +15,10 @@ Examples Part I {#intro1}
       cmake --build build -j4
       ./build/bin/Example1
 
+> **Note:** Job-prefix templates for `combineTool.py` understand the
+> `%(CH_BASE)s` placeholder, which refers to the repository root and defaults to
+> `$CMSSW_BASE/src` when `CH_BASE` is unset.
+
 Parsing a single card {#ex1-p1}
 ===============================
 In the first part we locate and open a single text datacard file:

--- a/docs/Example2.md
+++ b/docs/Example2.md
@@ -14,6 +14,10 @@ Examples Part II {#intro2}
       cmake --build build -j4
       ./build/bin/Example2
 
+> **Note:** Job-prefix templates for `combineTool.py` recognise the
+> `%(CH_BASE)s` placeholder pointing to the repository base. It falls back to
+> `$CMSSW_BASE/src` if `CH_BASE` is not defined.
+
 Defining categories and processes {#ex2-p1}
 ===========================================
 

--- a/docs/Example3.md
+++ b/docs/Example3.md
@@ -19,6 +19,10 @@ Examples Part III {#intro3}
       cmake --build build -j4
       ./build/bin/Example3
 
+> **Note:** Job-prefix templates used with `combineTool.py` recognise the
+> `%(CH_BASE)s` placeholder pointing to the repository root. If `CH_BASE` is not
+> set it falls back to `$CMSSW_BASE/src`.
+
 We start by defining four categories: A, B, C and D in the normal way. Contrary to the previous shape-based examples, with a counting experiment we have to specify all of the observed and expected yields directly. To start with we'll define a map containing the observed yields in each category.
 
 \snippet CombineTools/bin/Example3.cpp part1

--- a/docs/Main.md
+++ b/docs/Main.md
@@ -52,6 +52,10 @@ Set the `CH_BASE` environment variable to the repository location:
 export CH_BASE=$(pwd)
 ```
 
+Job-prefix templates such as those used by `combineTool.py` can reference this
+path via the `%(CH_BASE)s` placeholder, which defaults to `$CMSSW_BASE/src` when
+`CH_BASE` is unset.
+
 Auxiliary ROOT files used by some examples can be obtained with:
 
 ```


### PR DESCRIPTION
## Summary
- Replace CMSSW_BASE usage in NAF and IC job prefix templates with CH_BASE
- Allow CombineToolBase to substitute CH_BASE with sensible fallback
- Document CH_BASE placeholder in main guide and examples

## Testing
- `pytest` *(fails: Invalid initial character for a key part in pyproject.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9ce5a95c83298e380d1e70886d5a