### PR TITLE
Use python3 shebang for scripts

### DIFF
--- a/CombinePdfs/scripts/plotMorphing.py
+++ b/CombinePdfs/scripts/plotMorphing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import absolute_import
 from __future__ import print_function
 import sys

--- a/CombinePdfs/scripts/testBinning.py
+++ b/CombinePdfs/scripts/testBinning.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import absolute_import
 from __future__ import print_function
 import sys

--- a/CombineTools/python/combine/CovMatrix.py
+++ b/CombineTools/python/combine/CovMatrix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import
 from __future__ import print_function

--- a/CombineTools/python/combine/FastScan.py
+++ b/CombineTools/python/combine/FastScan.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import
 from __future__ import print_function

--- a/CombineTools/python/combine/Impacts.py
+++ b/CombineTools/python/combine/Impacts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import
 from __future__ import print_function

--- a/CombineTools/python/combine/ImpactsFromScans.py
+++ b/CombineTools/python/combine/ImpactsFromScans.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import
 from __future__ import print_function

--- a/CombineTools/python/combine/Output.py
+++ b/CombineTools/python/combine/Output.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import
 from __future__ import print_function

--- a/CombineTools/python/combine/TaylorExpand.py
+++ b/CombineTools/python/combine/TaylorExpand.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import
 from __future__ import print_function

--- a/CombineTools/python/combine/Workspace.py
+++ b/CombineTools/python/combine/Workspace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import
 from __future__ import print_function

--- a/CombineTools/python/pdgRounding.py
+++ b/CombineTools/python/pdgRounding.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python3
 
 # This class implements the pdg rounding rules indicated in
 # section 5.3 of doi:10.1088/0954-3899/33/1/001

--- a/CombineTools/scripts/HhhExample.py
+++ b/CombineTools/scripts/HhhExample.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import
 from __future__ import print_function

--- a/CombineTools/scripts/SMLegacyExample.py
+++ b/CombineTools/scripts/SMLegacyExample.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import
 from __future__ import print_function

--- a/CombineTools/scripts/injectBBH.py
+++ b/CombineTools/scripts/injectBBH.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import
 from __future__ import print_function

--- a/CombineTools/scripts/parseCombineWorkspaceExample.py
+++ b/CombineTools/scripts/parseCombineWorkspaceExample.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import
 from __future__ import print_function

--- a/CombineTools/scripts/partialCorrelationEdit.py
+++ b/CombineTools/scripts/partialCorrelationEdit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import absolute_import
 from __future__ import print_function
 import CombineHarvester.CombineTools.ch as ch

--- a/CombineTools/scripts/scaleGGH.py
+++ b/CombineTools/scripts/scaleGGH.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import
 from __future__ import print_function

--- a/CombineTools/scripts/scaleYR2ToYR3.py
+++ b/CombineTools/scripts/scaleYR2ToYR3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import
 from __future__ import print_function

--- a/CombineTools/scripts/setup-tH.py
+++ b/CombineTools/scripts/setup-tH.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import
 from __future__ import print_function

--- a/CombineTools/scripts/testingPyInterface.py
+++ b/CombineTools/scripts/testingPyInterface.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import absolute_import
 import CombineHarvester.CombineTools.ch as ch

--- a/CombineTools/scripts/updateBinBuildFile.py
+++ b/CombineTools/scripts/updateBinBuildFile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Example usage: updateBinBuildFile.py bin/BuildFile.xml bin/*.cpp
 from __future__ import absolute_import

--- a/docs/doxypypy/doxypypy.py
+++ b/docs/doxypypy/doxypypy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Filters Python code for use with Doxygen, using a syntax-aware approach.


### PR DESCRIPTION
## Summary
- update shebangs in CombineTools, CombinePdfs, and docs to `/usr/bin/env python3`
- ensure scripts remain executable

## Testing
- `python3 -m py_compile $(git ls-files CombineTools/python CombineTools/scripts CombinePdfs/python CombinePdfs/scripts docs/doxypypy | grep '\.py$')`


------
https://chatgpt.com/codex/tasks/task_e_68ba9d20d898832982c6913c5c160916