### PR TITLE
Resolve cppyy library paths using importlib.resources

### DIFF
--- a/CombinePdfs/python/morphing.py
+++ b/CombinePdfs/python/morphing.py
@@ -1,11 +1,36 @@
 from __future__ import absolute_import
-from os import environ
+import os
+from pathlib import Path
+from importlib.resources import files
 
 # Prevent cppyy's check for the PCH
-environ['CLING_STANDARD_PCH'] = 'none'
+os.environ['CLING_STANDARD_PCH'] = 'none'
 import cppyy
 
-cppyy.load_reflection_info("libCombineHarvesterCombinePdfs")
+
+def _load_library() -> None:
+    libname = "libCombineHarvesterCombinePdfs"
+    search_dir = os.environ.get("CH_LIBRARY_PATH")
+    if search_dir:
+        base = Path(search_dir)
+    else:
+        base = Path(files(__package__))
+    for ext in (".so", ".dylib"):
+        candidate = base / f"{libname}{ext}"
+        if candidate.exists():
+            try:
+                cppyy.load_reflection_info(str(candidate.resolve()))
+            except OSError as err:
+                raise OSError(
+                    f"Failed to load {candidate}. Rebuild the project or set CH_LIBRARY_PATH"
+                ) from err
+            return
+    raise OSError(
+        f"Could not find {libname}. Rebuild the project or set CH_LIBRARY_PATH to its location."
+    )
+
+
+_load_library()
 
 def BuildRooMorphing(ws, cb, bin, process, mass_var, norm_postfix='norm', allow_morph=True, verbose=False, force_template_limit=False, file=None):
     return cppyy.gbl.ch.BuildRooMorphing(ws, cb, bin, process, mass_var, norm_postfix, allow_morph, verbose, force_template_limit, file);


### PR DESCRIPTION
## Summary
- load CombineTools cppyy bindings from absolute paths using importlib.resources and CH_LIBRARY_PATH fallback
- add matching library loader for CombinePdfs bindings with helpful error messages

## Testing
- `python -m py_compile CombineTools/python/ch.py CombinePdfs/python/morphing.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba9d35a44c8329b32cb39f846d2f27