### PR TITLE
chore: drop six dependency

### DIFF
--- a/CombinePdfs/python/MSSM.py
+++ b/CombinePdfs/python/MSSM.py
@@ -9,8 +9,6 @@ import itertools
 import pprint
 import sys
 from collections import defaultdict
-import six
-from six.moves import range
 
 class MSSMHiggsModel(PhysicsModel):
     def __init__(self):
@@ -279,7 +277,7 @@ class MSSMHiggsModel(PhysicsModel):
         pars = [mA, tanb]
         doneMasses = False
 
-        for era, (file, version) in six.iteritems(self.modelFiles):
+        for era, (file, version) in self.modelFiles.items():
             hd = self.h_dict[version]
             f = ROOT.TFile(self.filePrefix + file)
 

--- a/CombinePdfs/python/ModelIndependent.py
+++ b/CombinePdfs/python/ModelIndependent.py
@@ -5,7 +5,6 @@ import os
 import ROOT
 import math
 import itertools
-import six
 
 class BRChargedHiggs(PhysicsModel):
     def __init__(self):
@@ -27,7 +26,7 @@ class BRChargedHiggs(PhysicsModel):
         # self.modelBuilder.out.Print()
 
     def getYieldScale(self,bin,process):
-        for prefix, model in six.iteritems(self.processScaling):
+        for prefix, model in self.processScaling.items():
             if process == prefix:
                 print('Scaling %s/%s as %s' % (bin, process, 'Scaling_'+model))
                 return 'Scaling_'+model

--- a/CombinePdfs/python/THDM.py
+++ b/CombinePdfs/python/THDM.py
@@ -7,8 +7,6 @@ import math
 import itertools
 import pprint
 import sys
-import six
-from six.moves import range
 
 class THDMHiggsModel(PhysicsModel):
     def __init__(self):
@@ -111,7 +109,7 @@ class THDMHiggsModel(PhysicsModel):
         pars = [mH, tanb]
         doneMasses = False
 
-        for era, (file, version) in six.iteritems(self.modelFiles):
+        for era, (file, version) in self.modelFiles.items():
             hd = self.h_dict[version]
             f = ROOT.TFile(self.filePrefix + file)
 

--- a/CombineTools/python/combine/EnhancedCombine.py
+++ b/CombineTools/python/combine/EnhancedCombine.py
@@ -7,8 +7,6 @@ import os
 import bisect
 from CombineHarvester.CombineTools.combine.opts import OPTS
 from CombineHarvester.CombineTools.combine.CombineToolBase import CombineToolBase
-import six
-from six.moves import zip
 
 
 def isfloat(value):
@@ -170,7 +168,7 @@ class EnhancedCombine(CombineToolBase):
             bound_vals = {}
             for par in bound_pars:
                 bound_vals[par] = list()
-                for mass, bounds in six.iteritems(bnd[par]):
+                for mass, bounds in bnd[par].items():
                     bound_vals[par].append((float(mass), bounds[0], bounds[1]))
                 bound_vals[par].sort(key=lambda x: x[0])
             # find the subbed_vars entry containing the mass

--- a/CombineTools/python/combine/LimitGrids.py
+++ b/CombineTools/python/combine/LimitGrids.py
@@ -15,8 +15,6 @@ from array import array
 import CombineHarvester.CombineTools.combine.utils as utils
 from CombineHarvester.CombineTools.combine.CombineToolBase import CombineToolBase
 import CombineHarvester.CombineTools.plotting as plot
-import six
-from six.moves import range
 
 class AsymptoticGrid(CombineToolBase):
     description = 'Calculate asymptotic limits on parameter grids'
@@ -93,7 +91,7 @@ class AsymptoticGrid(CombineToolBase):
             if p in file_dict:
                 file_dict[p].append(f)
 
-        for key,val in six.iteritems(file_dict):
+        for key, val in file_dict.items():
             name = '%s.%s.%s.%s' % (POIs[0], key[0], POIs[1], key[1])
             print('>> Point %s' % name)
             if len(val) == 0:
@@ -114,7 +112,7 @@ class AsymptoticGrid(CombineToolBase):
         xvals = []
         yvals = []
         zvals_m2s = []; zvals_m1s = []; zvals_exp = []; zvals_p1s = []; zvals_p2s = []; zvals_obs = []
-        for key,val in six.iteritems(file_dict):
+        for key, val in file_dict.items():
             for filename in val:
                 fin = ROOT.TFile(filename)
                 if fin.IsZombie(): continue
@@ -314,7 +312,7 @@ class HybridNewGrid(CombineToolBase):
 
         # Now do the full logic of the validation and return
         all_ok = (ntoys >= min_toys) # OK if min toys passes
-        for (key, val) in six.iteritems(signif_results):
+        for key, val in signif_results.items():
             all_ok = all_ok and val # still OK if all contour significances pass
         all_ok = all_ok or (ntoys >= max_toys) # Always OK if we've reached the maximum
         results['ok'] = all_ok
@@ -400,7 +398,7 @@ class HybridNewGrid(CombineToolBase):
                     bound_vals = {}
                     for par in bound_pars:
                         bound_vals[par] = list()
-                        for mass, bounds in six.iteritems(bnd[par]):
+                        for mass, bounds in bnd[par].items():
                             bound_vals[par].append((float(mass), bounds[0], bounds[1]))
                         bound_vals[par].sort(key=lambda x: x[0])
                 # print (min_limit, max_limit)
@@ -499,7 +497,7 @@ class HybridNewGrid(CombineToolBase):
         total_points = 0
         complete_points = 0
 
-        for key,val in six.iteritems(file_dict):
+        for key, val in file_dict.items():
             status_changed = True
             total_points += 1
             status_key = ':'.join(key)
@@ -659,11 +657,11 @@ class HybridNewGrid(CombineToolBase):
         if self.args.output and self.args.from_asymptotic:
             # Need to collect all the files for each mass point and hadd them:
             files_by_mass = {}
-            for key,val in six.iteritems(file_dict):
+            for key, val in file_dict.items():
                 if key[0] not in files_by_mass:
                     files_by_mass[key[0]] = list()
                 files_by_mass[key[0]].extend(list(val.values()))
-            for m, files in six.iteritems(files_by_mass):
+            for m, files in files_by_mass.items():
                 gridfile = 'higgsCombine.gridfile.%s.%s.%s.root' % (POIs[0], m, POIs[1])
                 self.job_queue.append('hadd -f %s %s' % (gridfile, ' '.join(files)))
                 for exp in ['', '0.025', '0.160', '0.500', '0.840', '0.975']:

--- a/CombineTools/python/combine/Output.py
+++ b/CombineTools/python/combine/Output.py
@@ -14,7 +14,6 @@ import CombineHarvester.CombineTools.plotting as plot
 # from CombineHarvester.CombineTools.combine.opts import OPTS
 
 from CombineHarvester.CombineTools.combine.CombineToolBase import CombineToolBase
-import six
 
 def isfloat(value):
     try:
@@ -61,7 +60,7 @@ class PrintFit(CombineToolBase):
                 val = res[p]
                 print('%-30s = %+.3f' % (p, val))
             if self.args.json is not None:
-                for key,val in six.iteritems(res):
+                for key, val in res.items():
                     js_target[key] = { 'Val' : val }
                 with open(json_structure[0], 'w') as outfile:
                     json.dump(js, outfile, sort_keys=True, indent=4, separators=(',', ': '))
@@ -128,7 +127,7 @@ class CollectLimits(CombineToolBase):
                 limit_sets[label].append(filename)
         # print limit_sets
 
-        for label, filenames in six.iteritems(limit_sets):
+        for label, filenames in limit_sets.items():
             js_out = {}
             for filename in filenames:
                 if plot.TFileIsGood(filename):
@@ -259,7 +258,7 @@ class CollectGoodnessOfFit(CombineToolBase):
                 limit_sets[label][0].append(filename)
 
 
-        for label, (filenames, toyfiles) in six.iteritems(limit_sets):
+        for label, (filenames, toyfiles) in limit_sets.items():
             js_out = {}
             for filename in filenames:
                 file = ROOT.TFile(filename)

--- a/CombineTools/python/combine/TaylorExpand.py
+++ b/CombineTools/python/combine/TaylorExpand.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
 import os
-import six.moves.cPickle as pickle
 import math
 import json
 import itertools
@@ -15,9 +14,7 @@ from pprint import pprint
 from functools import partial
 from CombineHarvester.CombineTools.combine.opts import OPTS
 from CombineHarvester.CombineTools.combine.CombineToolBase import CombineToolBase
-import six
-from six.moves import range
-from six.moves import zip
+import pickle
 
 
 def Eval(obj, x, params):
@@ -260,7 +257,7 @@ class TaylorExpand(CombineToolBase):
 
         if self.args.workspace_bestfit:
             fitvals = self.get_snpashot_pois(dc, POIs)
-            for POI, val in six.iteritems(fitvals):
+            for POI, val in fitvals.items():
                 print('>> Updating POI best fit from %f to %f' % (cfg[POI]["BestFit"], val))
                 cfg[POI]["BestFit"] = val
 
@@ -416,7 +413,7 @@ class TaylorExpand(CombineToolBase):
                 skip_term = False
                 for skip_item in can_skip:
                     has_all_terms = True
-                    for x, freq in six.iteritems(skip_item[1]):
+                    for x, freq in skip_item[1].items():
                         if item.count(x) < freq:
                             has_all_terms = False
                             break
@@ -576,7 +573,7 @@ class TaylorExpand(CombineToolBase):
         sorted_terms = []
         for i in range(self.args.order + 1):
             sorted_tmp = []
-            for tracker, val in six.iteritems(cached_terms):
+            for tracker, val in cached_terms.items():
                 if len(tracker) == i:
                     sorted_tmp.append((tracker, val))
                     if i == 2 and save_cov_matrix:

--- a/CombineTools/python/plotting.py
+++ b/CombineTools/python/plotting.py
@@ -6,9 +6,7 @@ from array import array
 import re
 import json
 import types
-import six
 import ctypes
-from six.moves import range
 
 COL_STORE = []
 
@@ -295,7 +293,7 @@ def CreateTransparentColor(color, alpha):
 
 
 def Set(obj, **kwargs):
-    for key, value in six.iteritems(kwargs):
+    for key, value in kwargs.items():
         if value is None:
             getattr(obj, 'Set' + key)()
         elif isinstance(value, (list, tuple)):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.8"
 dependencies = [
     "numpy",
     "cppyy",
-    "six",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- remove six dependency and replace helpers with Python 3 built-ins
- update scripts to use `dict.items()` and native modules
- drop six from project dependencies

## Testing
- `python3 -m py_compile CombinePdfs/python/ModelIndependent.py CombinePdfs/python/THDM.py CombinePdfs/python/MSSM.py CombineTools/python/plotting.py CombineTools/python/combine/EnhancedCombine.py CombineTools/python/combine/LimitGrids.py CombineTools/python/combine/TaylorExpand.py CombineTools/python/combine/Output.py`


------
https://chatgpt.com/codex/tasks/task_e_68baa807b5b48329a57c53da8be1e7fa