### PR TITLE
Use python3 shebang in scripts

### DIFF
--- a/CombinePdfs/python/MSSM.py
+++ b/CombinePdfs/python/MSSM.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+#!/usr/bin/env python3
 from HiggsAnalysis.CombinedLimit.PhysicsModel import *
 import CombineHarvester.CombineTools.plotting as plot
 import os

--- a/CombinePdfs/python/ModelIndependent.py
+++ b/CombinePdfs/python/ModelIndependent.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+#!/usr/bin/env python3
 from HiggsAnalysis.CombinedLimit.PhysicsModel import *
 import os
 import ROOT

--- a/CombinePdfs/python/THDM.py
+++ b/CombinePdfs/python/THDM.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+#!/usr/bin/env python3
 from HiggsAnalysis.CombinedLimit.PhysicsModel import *
 import os
 import ROOT

--- a/CombinePdfs/python/morphing.py
+++ b/CombinePdfs/python/morphing.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+#!/usr/bin/env python3
 import os
 from pathlib import Path
 from importlib.resources import files

--- a/CombinePdfs/scripts/plotMorphing.py
+++ b/CombinePdfs/scripts/plotMorphing.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-from __future__ import absolute_import
-from __future__ import print_function
 import sys
 import ROOT
 import math

--- a/CombinePdfs/scripts/testBinning.py
+++ b/CombinePdfs/scripts/testBinning.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-from __future__ import absolute_import
-from __future__ import print_function
 import sys
 import ROOT
 import math

--- a/CombineTools/python/__init__.py
+++ b/CombineTools/python/__init__.py
@@ -1,1 +1,2 @@
+#!/usr/bin/env python3
 """Python utilities for CombineHarvester."""

--- a/CombineTools/python/ch.py
+++ b/CombineTools/python/ch.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # This python module is essentially a thin wrapper around the real module which is embedded
 # in the shared library built by scram from the C++ source code. We import everything from
 # this module below, then attach a few functions that could not easily be wrapped from the
@@ -5,8 +6,6 @@
 # most notable example is the AddSyst method. The C++ version relies heavily on templates
 # which is not readily adaptable to python. Instead we write the functionality entirely in a
 # python function, then "attach" this function to the CombineHarvester class.
-from __future__ import absolute_import
-from __future__ import print_function
 import itertools
 import os
 from pathlib import Path

--- a/CombineTools/python/combine/CombineToolBase.py
+++ b/CombineTools/python/combine/CombineToolBase.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+#!/usr/bin/env python3
 import os
 import stat
 import shutil

--- a/CombineTools/python/combine/CovMatrix.py
+++ b/CombineTools/python/combine/CovMatrix.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import absolute_import
-from __future__ import print_function
 import ROOT
 
 import CombineHarvester.CombineTools.combine.utils as utils

--- a/CombineTools/python/combine/EnhancedCombine.py
+++ b/CombineTools/python/combine/EnhancedCombine.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+#!/usr/bin/env python3
 import itertools
 import CombineHarvester.CombineTools.combine.utils as utils
 import json

--- a/CombineTools/python/combine/FastScan.py
+++ b/CombineTools/python/combine/FastScan.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import absolute_import
-from __future__ import print_function
 import sys
 import json
 import ROOT

--- a/CombineTools/python/combine/Impacts.py
+++ b/CombineTools/python/combine/Impacts.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import absolute_import
-from __future__ import print_function
 import sys
 import re
 import json

--- a/CombineTools/python/combine/ImpactsFromScans.py
+++ b/CombineTools/python/combine/ImpactsFromScans.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import absolute_import
-from __future__ import print_function
 import argparse
 import os
 import re

--- a/CombineTools/python/combine/LimitGrids.py
+++ b/CombineTools/python/combine/LimitGrids.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+#!/usr/bin/env python3
 import ROOT
 import json
 import itertools

--- a/CombineTools/python/combine/Output.py
+++ b/CombineTools/python/combine/Output.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import absolute_import
-from __future__ import print_function
 import ROOT
 import json
 import os

--- a/CombineTools/python/combine/T2W.py
+++ b/CombineTools/python/combine/T2W.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+#!/usr/bin/env python3
 import itertools
 import CombineHarvester.CombineTools.combine.utils as utils
 import json

--- a/CombineTools/python/combine/TaylorExpand.py
+++ b/CombineTools/python/combine/TaylorExpand.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import absolute_import
-from __future__ import print_function
 import os
 import six.moves.cPickle as pickle
 import math

--- a/CombineTools/python/combine/Workspace.py
+++ b/CombineTools/python/combine/Workspace.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import absolute_import
-from __future__ import print_function
 import ROOT
 
 import CombineHarvester.CombineTools.combine.utils as utils

--- a/CombineTools/python/combine/__init__.py
+++ b/CombineTools/python/combine/__init__.py
@@ -1,1 +1,2 @@
+#!/usr/bin/env python3
 """Command line helper tools for CombineHarvester."""

--- a/CombineTools/python/combine/crab.py
+++ b/CombineTools/python/combine/crab.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """CRAB configuration used by CombineTool.
 
 This module builds and returns a :class:`WMCore.Configuration.Configuration`
@@ -11,7 +12,6 @@ If the executable cannot be located it will not be added to the list of files
 sent with the job and a warning will be emitted.
 """
 
-from __future__ import absolute_import
 
 import os
 import warnings

--- a/CombineTools/python/combine/opts.py
+++ b/CombineTools/python/combine/opts.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # a dictionary with some pre-defined (mostly minimizer) combine options
 
 OPTS = {

--- a/CombineTools/python/combine/rounding.py
+++ b/CombineTools/python/combine/rounding.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Performs rounding of values with uncertainties and produces output that can be used in ROOT or LaTeX
 
@@ -5,8 +6,6 @@ Written by andre.david@cern.ch
 """
 
 
-from __future__ import absolute_import
-from __future__ import print_function
 from math import *
 from decimal import *
 from six.moves import range

--- a/CombineTools/python/combine/utils.py
+++ b/CombineTools/python/combine/utils.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+#!/usr/bin/env python3
 import ROOT
 import re
 

--- a/CombineTools/python/maketable.py
+++ b/CombineTools/python/maketable.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+#!/usr/bin/env python3
 import CombineHarvester.CombineTools.plotting as plot
 import ROOT as R
 from array import array

--- a/CombineTools/python/pdgRounding.py
+++ b/CombineTools/python/pdgRounding.py
@@ -12,7 +12,6 @@
 # davide.gerbaudo@gmail.com
 # September 2012
 
-from __future__ import print_function
 import argparse
 
 def pdgRound(value, error) :

--- a/CombineTools/python/plotting.py
+++ b/CombineTools/python/plotting.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+#!/usr/bin/env python3
 import ROOT as R
 import math
 from array import array

--- a/CombineTools/python/systematics/Hhh.py
+++ b/CombineTools/python/systematics/Hhh.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+#!/usr/bin/env python3
 import CombineHarvester.CombineTools.ch as ch
 
 def AddSystematics_hhh_et_mt(cb):

--- a/CombineTools/python/systematics/SMLegacy.py
+++ b/CombineTools/python/systematics/SMLegacy.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+#!/usr/bin/env python3
 import CombineHarvester.CombineTools.ch as ch
 
 def AddSystematics_ee_mm(cb):

--- a/CombineTools/python/systematics/__init__.py
+++ b/CombineTools/python/systematics/__init__.py
@@ -1,1 +1,2 @@
+#!/usr/bin/env python3
 """Systematics modules for CombineHarvester."""

--- a/CombineTools/scripts/Example3.py
+++ b/CombineTools/scripts/Example3.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+#!/usr/bin/env python3
 import CombineHarvester.CombineTools.ch as ch
 
 cb = ch.CombineHarvester()

--- a/CombineTools/scripts/HhhExample.py
+++ b/CombineTools/scripts/HhhExample.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import absolute_import
-from __future__ import print_function
 import CombineHarvester.CombineTools.ch as ch
 import CombineHarvester.CombineTools.systematics.Hhh as HhhSysts
 import ROOT as R

--- a/CombineTools/scripts/MSSMtanbPlot.py
+++ b/CombineTools/scripts/MSSMtanbPlot.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+#!/usr/bin/env python3
 import CombineHarvester.CombineTools.plotting as plot
 import ROOT
 import math

--- a/CombineTools/scripts/SMLegacyExample.py
+++ b/CombineTools/scripts/SMLegacyExample.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import absolute_import
-from __future__ import print_function
 import CombineHarvester.CombineTools.ch as ch
 import CombineHarvester.CombineTools.systematics.SMLegacy as SMLegacySysts
 import ROOT as R

--- a/CombineTools/scripts/ValidateDatacards.py
+++ b/CombineTools/scripts/ValidateDatacards.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import absolute_import
-from __future__ import print_function
 import CombineHarvester.CombineTools.ch as ch
 import ROOT as R
 import glob

--- a/CombineTools/scripts/__init__.py
+++ b/CombineTools/scripts/__init__.py
@@ -1,1 +1,2 @@
+#!/usr/bin/env python3
 """Auxiliary scripts for CombineHarvester."""

--- a/CombineTools/scripts/custom_crab.py
+++ b/CombineTools/scripts/custom_crab.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+#!/usr/bin/env python3
 def custom_crab(config):
     print('>> Customising the crab config')
     config.User.voGroup = 'dcms'

--- a/CombineTools/scripts/do_nothing_cfg.py
+++ b/CombineTools/scripts/do_nothing_cfg.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+#!/usr/bin/env python3
 
 try:
     import FWCore.ParameterSet.Config as cms

--- a/CombineTools/scripts/injectBBH.py
+++ b/CombineTools/scripts/injectBBH.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import absolute_import
-from __future__ import print_function
 import CombineHarvester.CombineTools.ch as ch
 import ROOT as R
 import glob

--- a/CombineTools/scripts/parseCombineWorkspaceExample.py
+++ b/CombineTools/scripts/parseCombineWorkspaceExample.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import absolute_import
-from __future__ import print_function
 import CombineHarvester.CombineTools.ch as ch
 import ROOT
 import sys

--- a/CombineTools/scripts/partialCorrelationEdit.py
+++ b/CombineTools/scripts/partialCorrelationEdit.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-from __future__ import absolute_import
-from __future__ import print_function
 import CombineHarvester.CombineTools.ch as ch
 import ROOT
 import argparse

--- a/CombineTools/scripts/scaleGGH.py
+++ b/CombineTools/scripts/scaleGGH.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import absolute_import
-from __future__ import print_function
 import CombineHarvester.CombineTools.ch as ch
 import ROOT as R
 import glob

--- a/CombineTools/scripts/scaleYR2ToYR3.py
+++ b/CombineTools/scripts/scaleYR2ToYR3.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import absolute_import
-from __future__ import print_function
 import CombineHarvester.CombineTools.ch as ch
 import ROOT as R
 import glob

--- a/CombineTools/scripts/setup-tH.py
+++ b/CombineTools/scripts/setup-tH.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import absolute_import
-from __future__ import print_function
 import CombineHarvester.CombineTools.ch as ch
 import os
 

--- a/CombineTools/scripts/simpleLimits.py
+++ b/CombineTools/scripts/simpleLimits.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+#!/usr/bin/env python3
 import ROOT
 from CombineHarvester.CombineTools.plotting import *
 ROOT.PyConfig.IgnoreCommandLineOptions = True

--- a/CombineTools/scripts/testingPyInterface.py
+++ b/CombineTools/scripts/testingPyInterface.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import absolute_import
 import CombineHarvester.CombineTools.ch as ch
 cb = ch.CombineHarvester()
 cb.SetFlag('check-negative-bins-on-import', 0)

--- a/CombineTools/scripts/updateBinBuildFile.py
+++ b/CombineTools/scripts/updateBinBuildFile.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
 # Example usage: updateBinBuildFile.py bin/BuildFile.xml bin/*.cpp
-from __future__ import absolute_import
-from __future__ import print_function
 import os
 import sys
 

--- a/docs/doxypypy/doxypypy.py
+++ b/docs/doxypypy/doxypypy.py
@@ -13,8 +13,6 @@ Google style guide into appropriate Doxygen tags, and is even aware of
 doctests.
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
 from ast import NodeVisitor, parse, iter_fields, AST, Name, get_docstring
 from re import compile as regexpCompile, IGNORECASE, MULTILINE
 from types import GeneratorType


### PR DESCRIPTION
## Summary
- Use `/usr/bin/env python3` shebang across CombineTools, CombinePdfs, and docs scripts
- Drop obsolete `from __future__` imports
- Preserve executable bits for modified Python scripts

## Testing
- `python3 -m py_compile $(find CombineTools/scripts CombineTools/python CombinePdfs/scripts CombinePdfs/python docs/doxypypy -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68baa813a93c832980e7ca0f73402ea8