### PR TITLE
Use CH_BASE for path discovery and docs

### DIFF
--- a/CombinePdfs/python/ModelIndependent.py
+++ b/CombinePdfs/python/ModelIndependent.py
@@ -114,7 +114,7 @@ class FloatingMSSMXSHiggs(MSSMLikeHiggsModel):
         ## the values are given by the value in brakets. In principle three values can be passed on: value, lower bound and upper
         ## bound.
         #
-        #mssm_scan = mssm_xsec_tools("{CMSSW_BASE}/src/{PATH}".format(CMSSW_BASE=os.environ['CMSSW_BASE'], PATH="HiggsAnalysis/HiggsToTauTau/data/out.mhmax-mu+200-7TeV-nnlo.root"))
+        #mssm_scan = mssm_xsec_tools("{CH_BASE}/{PATH}".format(CH_BASE=os.environ['CH_BASE'], PATH="HiggsAnalysis/HiggsToTauTau/data/out.mhmax-mu+200-7TeV-nnlo.root"))
         #mssm_xsec = mssm_scan.query(self.options.mass, float(self.tanb))
         #self.modelBuilder.doVar("bbH_xsec[%g]" % (mssm_xsec['higgses']['A']['xsec']['santander']*mssm_xsec['higgses']['A']['BR']))
         #self.modelBuilder.doVar("ggH_xsec[%g]" % (mssm_xsec['higgses']['A']['xsec']['ggF'      ]*mssm_xsec['higgses']['A']['BR']))

--- a/CombineTools/python/combine/CombineToolBase.py
+++ b/CombineTools/python/combine/CombineToolBase.py
@@ -7,6 +7,7 @@ from functools import partial
 from multiprocessing import Pool
 from six.moves import range
 from importlib import resources
+import CombineHarvester.CombineTools.ch as ch
 
 DRY_RUN = False
 
@@ -130,12 +131,7 @@ class CombineToolBase:
         self.cmssw_base = os.environ.get('CMSSW_BASE')
         self.scram_arch = os.environ.get('SCRAM_ARCH')
         self.standalone = False
-        self.ch_base = os.environ.get('CH_BASE')
-        if not self.ch_base:
-            if self.cmssw_base:
-                self.ch_base = os.path.join(self.cmssw_base, 'src')
-            else:
-                self.ch_base = os.getcwd()
+        self.ch_base = os.environ.get('CH_BASE', ch.paths.base())
         self.job_prefix = _build_job_prefix(self.cmssw_base, self.scram_arch, self.standalone)
 
     def attach_job_args(self, group):

--- a/CombineTools/scripts/HhhExample.py
+++ b/CombineTools/scripts/HhhExample.py
@@ -10,9 +10,8 @@ import os
 
 cb = ch.CombineHarvester()
 
-ch_base = os.environ.get('CH_BASE', os.environ.get('CMSSW_BASE', '') + '/src/CombineHarvester')
-auxiliaries  = os.environ.get('CH_AUXILIARIES', ch_base + '/auxiliaries/')
-aux_shapes   = auxiliaries + 'shapes/'
+auxiliaries = os.environ.get('CH_AUXILIARIES', ch.paths.auxiliaries())
+aux_shapes = os.path.join(auxiliaries, 'shapes') + '/'
 
 chns = ['et', 'mt', 'tt']
 

--- a/CombineTools/scripts/SMLegacyExample.py
+++ b/CombineTools/scripts/SMLegacyExample.py
@@ -11,10 +11,9 @@ from importlib import resources
 
 cb = ch.CombineHarvester()
 
-ch_base = os.environ.get('CH_BASE', os.environ.get('CMSSW_BASE', '') + '/src/CombineHarvester')
-auxiliaries  = os.environ.get('CH_AUXILIARIES', ch_base + '/auxiliaries/')
-aux_shapes   = auxiliaries + 'shapes/'
-aux_pruning  = auxiliaries + 'pruning/'
+auxiliaries = os.environ.get('CH_AUXILIARIES', ch.paths.auxiliaries())
+aux_shapes = os.path.join(auxiliaries, 'shapes') + '/'
+aux_pruning = os.path.join(auxiliaries, 'pruning') + '/'
 input_dir = resources.files('CombineHarvester.CombineTools.input')
 
 chns = ['et', 'mt', 'em', 'ee', 'mm', 'tt']

--- a/CombineTools/scripts/setup-tH.py
+++ b/CombineTools/scripts/setup-tH.py
@@ -7,9 +7,8 @@ import os
 
 cb = ch.CombineHarvester()
 
-ch_base = os.environ.get('CH_BASE', os.environ.get('CMSSW_BASE', '') + '/src/CombineHarvester')
-auxiliaries  = os.environ.get('CH_AUXILIARIES', ch_base + '/auxiliaries/')
-aux_shapes   = auxiliaries + 'shapes/'
+auxiliaries = os.environ.get('CH_AUXILIARIES', ch.paths.auxiliaries())
+aux_shapes = os.path.join(auxiliaries, 'shapes') + '/'
 
 procs = {
   'sig'  : ['tH_YtMinus', 'tHW'],

--- a/docs/Example1.md
+++ b/docs/Example1.md
@@ -16,8 +16,8 @@ Examples Part I {#intro1}
       ./build/bin/Example1
 
 > **Note:** Job-prefix templates for `combineTool.py` understand the
-> `%(CH_BASE)s` placeholder, which refers to the repository root and defaults to
-> `$CMSSW_BASE/src` when `CH_BASE` is unset.
+> `%(CH_BASE)s` placeholder, which points to the repository root and can be
+> overridden with the `CH_BASE` environment variable.
 
 Parsing a single card {#ex1-p1}
 ===============================

--- a/docs/Example2.md
+++ b/docs/Example2.md
@@ -15,8 +15,8 @@ Examples Part II {#intro2}
       ./build/bin/Example2
 
 > **Note:** Job-prefix templates for `combineTool.py` recognise the
-> `%(CH_BASE)s` placeholder pointing to the repository base. It falls back to
-> `$CMSSW_BASE/src` if `CH_BASE` is not defined.
+> `%(CH_BASE)s` placeholder pointing to the repository root and can be
+> overridden with the `CH_BASE` environment variable.
 
 Defining categories and processes {#ex2-p1}
 ===========================================

--- a/docs/Example3.md
+++ b/docs/Example3.md
@@ -20,8 +20,8 @@ Examples Part III {#intro3}
       ./build/bin/Example3
 
 > **Note:** Job-prefix templates used with `combineTool.py` recognise the
-> `%(CH_BASE)s` placeholder pointing to the repository root. If `CH_BASE` is not
-> set it falls back to `$CMSSW_BASE/src`.
+> `%(CH_BASE)s` placeholder pointing to the repository root and can be
+> overridden with the `CH_BASE` environment variable.
 
 We start by defining four categories: A, B, C and D in the normal way. Contrary to the previous shape-based examples, with a counting experiment we have to specify all of the observed and expected yields directly. To start with we'll define a map containing the observed yields in each category.
 

--- a/docs/Main.md
+++ b/docs/Main.md
@@ -53,8 +53,8 @@ export CH_BASE=$(pwd)
 ```
 
 Job-prefix templates such as those used by `combineTool.py` can reference this
-path via the `%(CH_BASE)s` placeholder, which defaults to `$CMSSW_BASE/src` when
-`CH_BASE` is unset.
+path via the `%(CH_BASE)s` placeholder. The path is determined automatically
+when `CH_BASE` is unset.
 
 Auxiliary ROOT files used by some examples can be obtained with:
 


### PR DESCRIPTION
## Summary
- Replace CMSSW_BASE lookups with `ch.paths.auxiliaries()` or `CH_BASE`
- Document CH_BASE usage instead of CMSSW_BASE

## Testing
- `python -m py_compile CombineTools/scripts/SMLegacyExample.py CombineTools/scripts/setup-tH.py CombineTools/scripts/HhhExample.py CombineTools/python/combine/CombineToolBase.py CombinePdfs/python/ModelIndependent.py`
- `python CombineTools/scripts/setup-tH.py` *(fails: No module named 'cppyy')*


------
https://chatgpt.com/codex/tasks/task_e_68baa81a80548329a874e4e1ae6242e9