### PR TITLE
Build Python package with CMake-generated libraries

### DIFF
--- a/CombinePdfs/python/__init__.py
+++ b/CombinePdfs/python/__init__.py
@@ -1,0 +1,5 @@
+"""Python bindings for CombineHarvester probability density functions."""
+
+from .morphing import BuildCMSHistFuncFactory, BuildRooMorphing  # noqa: F401
+
+__all__ = ["BuildCMSHistFuncFactory", "BuildRooMorphing"]

--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ cmake -S . -B build
 cmake --build build -j4
 ```
 
-The build requires the **vdt** and **HistFactory** libraries. These are
-often provided with ROOT. Set the `ROOTSYS` environment variable to the
-location of your ROOT installation so that the headers and libraries can
-be discovered:
+The build requires several external C++ libraries: [ROOT](https://root.cern)
+(with the RooFit and RooStats components), Boost, libxml2, vdt and
+HistFactory. These dependencies must be installed and discoverable by
+CMake. ROOT often provides vdt and HistFactory. Set the `ROOTSYS`
+environment variable to the location of your ROOT installation so that
+the headers and libraries can be found:
 
 ```
 export ROOTSYS=/path/to/root

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=61", "wheel", "cmake", "ninja"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -30,6 +30,7 @@ packages = [
     "CombineHarvester.CombineTools.input.examples",
     "CombineHarvester.CombineTools.input.job_prefixes",
     "CombineHarvester.CombineTools.input.xsecs_brs",
+    "CombineHarvester.CombinePdfs",
 ]
 
 [tool.setuptools.package-dir]
@@ -42,6 +43,7 @@ packages = [
 "CombineHarvester.CombineTools.input.examples" = "CombineTools/input/examples"
 "CombineHarvester.CombineTools.input.job_prefixes" = "CombineTools/input/job_prefixes"
 "CombineHarvester.CombineTools.input.xsecs_brs" = "CombineTools/input/xsecs_brs"
+"CombineHarvester.CombinePdfs" = "CombinePdfs/python"
 
 [tool.setuptools.package-data]
 "CombineHarvester.CombineTools" = ["*.so"]
@@ -50,3 +52,4 @@ packages = [
 "CombineHarvester.CombineTools.input.examples" = ["*"]
 "CombineHarvester.CombineTools.input.job_prefixes" = ["*"]
 "CombineHarvester.CombineTools.input.xsecs_brs" = ["*"]
+"CombineHarvester.CombinePdfs" = ["*.so"]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,29 @@
+import subprocess
+import sys
+import shutil
+from pathlib import Path
+
+from setuptools import setup
+from setuptools.command.build_ext import build_ext
+
+
+class CMakeBuild(build_ext):
+    def run(self):
+        super().run()
+        build_temp = Path(self.build_temp)
+        build_temp.mkdir(parents=True, exist_ok=True)
+        source_dir = Path(__file__).resolve().parent
+        subprocess.check_call(["cmake", "-S", str(source_dir), "-B", str(build_temp)])
+        subprocess.check_call(["cmake", "--build", str(build_temp), "--target", "CombineTools", "CombinePdfs"])
+        suffix = ".dll" if sys.platform == "win32" else (".dylib" if sys.platform == "darwin" else ".so")
+        dest_tools = Path(self.build_lib) / "CombineHarvester" / "CombineTools"
+        dest_pdfs = Path(self.build_lib) / "CombineHarvester" / "CombinePdfs"
+        dest_tools.mkdir(parents=True, exist_ok=True)
+        dest_pdfs.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(build_temp / "CombineTools" / f"libCombineTools{suffix}",
+                     dest_tools / f"libCombineHarvesterCombineTools{suffix}")
+        shutil.copy2(build_temp / "CombinePdfs" / f"libCombinePdfs{suffix}",
+                     dest_pdfs / f"libCombineHarvesterCombinePdfs{suffix}")
+
+
+setup(cmdclass={"build_ext": CMakeBuild})


### PR DESCRIPTION
## Summary
- run CMake during wheel build and copy resulting libraries into the Python package
- ship CombinePdfs Python bindings and compiled library
- document required C++ prerequisites
- update pyproject build-system requirements and package metadata

## Testing
- `python -m py_compile CombinePdfs/python/__init__.py setup.py`
- `pip install --upgrade pip` *(fails: Cannot connect to proxy, tunnel connection failed: 403 Forbidden)*
- `pip install .` *(fails: could not find setuptools>=61 due to proxy restrictions)*


------
https://chatgpt.com/codex/tasks/task_e_68baa82e1b84832990174dbedf66bef5