### PR TITLE
refactor: drop six usage

### DIFF
--- a/CombinePdfs/scripts/testBinning.py
+++ b/CombinePdfs/scripts/testBinning.py
@@ -6,7 +6,6 @@ from functools import partial
 import Tools.Plotting.plotting as plot
 import os.path
 import bisect
-from six.moves import range
 
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 ROOT.gROOT.SetBatch(ROOT.kTRUE)

--- a/CombineTools/python/combine/CombineToolBase.py
+++ b/CombineTools/python/combine/CombineToolBase.py
@@ -4,7 +4,6 @@ import stat
 import shutil
 from functools import partial
 from multiprocessing import Pool
-from six.moves import range
 from importlib import resources
 import CombineHarvester.CombineTools.ch as ch
 
@@ -364,7 +363,7 @@ class CombineToolBase:
         if self.job_mode == 'crab3':
             #import the stuff we need
             from CRABAPI.RawCommand import crabCommand
-            from six.moves.http_client import HTTPException
+            from http.client import HTTPException
             print('>> crab3 requestName will be %s' % self.task_name)
             outscriptname = 'crab_%s.sh' % self.task_name
             print('>> crab3 script will be %s' % outscriptname)

--- a/CombineTools/python/combine/CovMatrix.py
+++ b/CombineTools/python/combine/CovMatrix.py
@@ -6,7 +6,6 @@ import CombineHarvester.CombineTools.combine.utils as utils
 from CombineHarvester.CombineTools.combine.opts import OPTS
 
 from CombineHarvester.CombineTools.combine.CombineToolBase import CombineToolBase
-from six.moves import range
 import ctypes
 
 class CovMatrix(CombineToolBase):

--- a/CombineTools/python/combine/FastScan.py
+++ b/CombineTools/python/combine/FastScan.py
@@ -8,7 +8,6 @@ import CombineHarvester.CombineTools.combine.utils as utils
 
 from CombineHarvester.CombineTools.combine.CombineToolBase import CombineToolBase
 import CombineHarvester.CombineTools.plotting as plot
-from six.moves import range
 
 
 class FastScan(CombineToolBase):

--- a/CombineTools/python/combine/Impacts.py
+++ b/CombineTools/python/combine/Impacts.py
@@ -7,7 +7,6 @@ import ROOT
 import CombineHarvester.CombineTools.combine.utils as utils
 
 from CombineHarvester.CombineTools.combine.CombineToolBase import CombineToolBase
-from six.moves import map
 
 
 class Impacts(CombineToolBase):

--- a/CombineTools/python/combine/ImpactsFromScans.py
+++ b/CombineTools/python/combine/ImpactsFromScans.py
@@ -18,7 +18,6 @@ import CombineHarvester.CombineTools.combine.utils as utils
 from CombineHarvester.CombineTools.combine.opts import OPTS
 
 from CombineHarvester.CombineTools.combine.CombineToolBase import CombineToolBase
-from six.moves import range
 import ctypes
 
 class ImpactsFromScans(CombineToolBase):

--- a/CombineTools/python/combine/rounding.py
+++ b/CombineTools/python/combine/rounding.py
@@ -8,7 +8,6 @@ Written by andre.david@cern.ch
 
 from math import *
 from decimal import *
-from six.moves import range
 
 ###
 def roundUnc(unc, method="Publication"):

--- a/CombineTools/python/maketable.py
+++ b/CombineTools/python/maketable.py
@@ -3,7 +3,6 @@ import CombineHarvester.CombineTools.plotting as plot
 import ROOT as R
 from array import array
 import json
-from six.moves import range
 
 def Tablefrom1DGraph(rootfile, filename):
     graph = [R.TGraph() for i in range(6)]

--- a/CombineTools/scripts/MSSMtanbPlot.py
+++ b/CombineTools/scripts/MSSMtanbPlot.py
@@ -3,7 +3,6 @@ import CombineHarvester.CombineTools.plotting as plot
 import ROOT
 import math
 import argparse
-from six.moves import range
 
 
 col_store = []

--- a/CombineTools/scripts/scaleGGH.py
+++ b/CombineTools/scripts/scaleGGH.py
@@ -3,7 +3,6 @@
 import CombineHarvester.CombineTools.ch as ch
 import ROOT as R
 import glob
-import six
 
 # OLD inclusive distribution
 # SCALES = {
@@ -110,7 +109,7 @@ SCALES_8TEV = {
 }
 
 def DoScales(cmb, scales):
-    for key, val in six.iteritems(scales):
+    for key, val in scales.items():
         print('Scaling ' + str(key) + ' by ' + str(val))
         cmb.cp().process(["ggH"]).channel([key[0]]).bin_id([key[1]]).ForEachProc(lambda x : x.set_rate(x.rate() * val))
         cmb.cp().process(["ggH"]).channel([key[0]]).bin_id([key[1]]).PrintProcs()

--- a/CombineTools/scripts/scaleYR2ToYR3.py
+++ b/CombineTools/scripts/scaleYR2ToYR3.py
@@ -3,7 +3,6 @@
 import CombineHarvester.CombineTools.ch as ch
 import ROOT as R
 import glob
-import six
 
 SCALES_XSEC_7TEV = {
   "^ggH(|_hww|_htt)$" : 15.13/15.31,
@@ -25,7 +24,7 @@ SCALES_BR = {
 }
 
 def DoScales(cmb, scales):
-    for key, val in six.iteritems(scales):
+    for key, val in scales.items():
         print('Scaling ' + key + ' by ' + str(val))
         cmb.cp().process_rgx([key]).ForEachProc(lambda x : x.set_rate(x.rate() * val))
         cmb.cp().process_rgx([key]).PrintProcs()


### PR DESCRIPTION
## Summary
- drop `six` and `six.moves` imports across scripts and combine modules
- replace `six.iteritems` with `.items()` in scaling helpers
- use `http.client.HTTPException` directly in CombineToolBase

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68baeca404f4832985c8407efed099e9