### PR TITLE
Document standalone installation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,18 @@ Continuous integration and automated checks now run on GitHub Actions. The previ
 
 ## Installation
 
-The project can be built as a standalone package with [CMake](https://cmake.org/). Clone the repository and initialise the submodules:
+See the [standalone installation guide](docs/StandaloneInstallation.md) for
+full details.  A typical quick-start workflow is:
 
 ```
 git clone https://github.com/cms-analysis/CombineHarvester.git
 cd CombineHarvester
-git submodule update --init --recursive
-```
-
-Configure and build the project:
-
-```
+git submodule update --init
 cmake -S . -B build
-cmake --build build -j4
+cmake --build build --target install
+export CH_BASE=$(pwd)
+source build/setup.sh
+$CH_BASE/build/bin/Example1
 ```
 
 The build requires several external C++ libraries: [ROOT](https://root.cern)

--- a/docs/BuildSystem.md
+++ b/docs/BuildSystem.md
@@ -1,17 +1,16 @@
 Build System {#build}
 ====================
 
-CombineHarvester is built with [CMake](https://cmake.org/) and no CMSSW
-environment is required.  The repository contains two main packages,
-`CombineTools` and `CombinePdfs`, which are configured and compiled in a
-single CMake project.
+CombineHarvester is built with [CMake](https://cmake.org/).  The repository
+contains two main packages, `CombineTools` and `CombinePdfs`, which are
+configured and compiled in a single CMake project.
 
-See the [standalone installation instructions](../README.md#installation)
-for the initial checkout of the repository.  A typical build workflow is:
+See the [standalone installation guide](StandaloneInstallation.md) for the
+repository setup.  A typical build workflow is:
 
 ```
 cmake -S . -B build
-cmake --build build -j4
+cmake --build build --target install
 ```
 
 Libraries and executables are placed in `build/lib` and `build/bin`.  The

--- a/docs/Main.md
+++ b/docs/Main.md
@@ -26,57 +26,20 @@ As well as histogram-based templates, the production of datacards with arbitrary
 
 Getting started {#getting-started}
 ==================================
-CombineHarvester can now be used as a standalone project. It currently provides two sub-packages:
+CombineHarvester can now be used as a standalone project.  See the
+[standalone installation guide](StandaloneInstallation.md) for the
+repository checkout and build instructions.  It currently provides two
+sub-packages:
 
   * **CombineHarvester/CombineTools**, which contains the CombineHarvester class and other parts of the core framework
   * **CombineHarvester/CombinePdfs**, which provides tools for building custom RooFit pdfs
 
-Clone the repository and initialise the submodules:
+After building, example programs can be invoked directly, e.g.
 
 ```
-git clone https://github.com/cms-analysis/CombineHarvester.git
-cd CombineHarvester
-git submodule update --init --recursive
-```
-
-Build the code with CMake:
-
-```
-cmake -S . -B build
-cmake --build build -j4
-```
-
-Set the `CH_BASE` environment variable to the repository location:
-
-```
-export CH_BASE=$(pwd)
-```
-
-Job-prefix templates such as those used by `combineTool.py` can reference this
-path via the `%(CH_BASE)s` placeholder. The path is determined automatically
-when `CH_BASE` is unset.
-
-Auxiliary ROOT files used by some examples can be obtained with:
-
-```
-git clone https://github.com/roger-wolf/HiggsAnalysis-HiggsToTauTau-auxiliaries.git "$CH_BASE/auxiliaries"
-```
-
-After building, example programs can be invoked directly without a CMSSW environment, e.g.
-
-```
-./build/bin/Example1
+$CH_BASE/build/bin/Example1
 python3 CombineTools/scripts/Example3.py
 ```
-
-### Compatibility with CMSSW
-
-For backward support the framework remains compatible with the CMSSW 14_1_X
-and 11_3_X series releases. The repository may still be placed inside a
-CMSSW release area under `src/CombineHarvester` alongside
-`HiggsAnalysis/CombinedLimit` and compiled with `scram b` following the
-recommendations of the combine developers. Job scripts will attempt to set up
-this environment unless the `--standalone` option is given.
 
 If you are using this framework for the first time we recommend taking a look through some of the examples below which demonstrate the main features:
 

--- a/docs/StandaloneInstallation.md
+++ b/docs/StandaloneInstallation.md
@@ -1,0 +1,48 @@
+# Standalone Installation
+
+This guide describes how to build and run CombineHarvester as a standalone project.
+
+## Prerequisites
+
+The following external libraries must be available and discoverable by CMake:
+
+* [ROOT](https://root.cern) with the RooFit and RooStats components
+* [Boost](https://www.boost.org/)
+* [libxml2](http://xmlsoft.org/)
+* [vdt](https://gitlab.cern.ch/vdt/vdt)
+* [HistFactory](https://root.cern.ch/doc/master/group__HistFactory.html)
+
+ROOT often bundles vdt and HistFactory.  Set `ROOTSYS` to the location of your
+ROOT installation if required.
+
+## Repository setup
+
+```bash
+git clone https://github.com/cms-analysis/CombineHarvester.git
+cd CombineHarvester
+git submodule update --init
+```
+
+## Building with CMake
+
+```bash
+cmake -S . -B build
+cmake --build build --target install
+```
+
+## Environment setup
+
+```bash
+export CH_BASE=$(pwd)
+source build/setup.sh
+```
+
+## Smoke test
+
+Run one of the example programs to verify the installation:
+
+```bash
+$CH_BASE/build/bin/Example1
+```
+
+This should print a short message and exit without error.


### PR DESCRIPTION
## Summary
- Document standalone installation prerequisites and workflow
- Link README and build docs to the new standalone guide
- Drop CMSSW references from Main and BuildSystem docs

## Testing
- `cmake -S . -B build` *(fails: HiggsAnalysis/CombinedLimit not found)*
- `cmake --build build --target install` *(fails: No rule to make target 'Makefile')*


------
https://chatgpt.com/codex/tasks/task_e_68baef9678588329b8c140e7c155372c