### PR TITLE
Auto-fetch HiggsAnalysis CombinedLimit during build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,16 +4,24 @@ project(CombineHarvester)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 option(USE_SYSTEM_COMBINEDLIMIT "Use system-installed HiggsAnalysisCombinedLimit" OFF)
+set(COMBINEDLIMIT_TAG "v10.2.7" CACHE STRING "Git tag or commit of HiggsAnalysis-CombinedLimit to fetch")
 
 if(USE_SYSTEM_COMBINEDLIMIT)
   find_package(HiggsAnalysisCombinedLimit REQUIRED)
 else()
-  if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/HiggsAnalysis/CombinedLimit/CMakeLists.txt")
-    message(FATAL_ERROR "HiggsAnalysis/CombinedLimit not found. Either enable USE_SYSTEM_COMBINEDLIMIT or fetch the sources as described in the README")
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/HiggsAnalysis/CombinedLimit/CMakeLists.txt")
+    add_subdirectory(HiggsAnalysis/CombinedLimit)
+    set(HiggsAnalysisCombinedLimit_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/HiggsAnalysis/CombinedLimit)
+  else()
+    include(FetchContent)
+    FetchContent_Declare(CombinedLimit
+      GIT_REPOSITORY https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git
+      GIT_TAG        ${COMBINEDLIMIT_TAG}
+    )
+    FetchContent_MakeAvailable(CombinedLimit)
+    set(HiggsAnalysisCombinedLimit_SOURCE_DIR ${combinedlimit_SOURCE_DIR})
   endif()
-  add_subdirectory(HiggsAnalysis/CombinedLimit)
-  set(HiggsAnalysisCombinedLimit_LIBRARIES HiggsAnalysisCombinedLimit)
-  set(HiggsAnalysisCombinedLimit_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/HiggsAnalysis/CombinedLimit/interface)
+  add_library(HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit ALIAS HiggsAnalysisCombinedLimit)
 endif()
 
 find_package(ROOT REQUIRED COMPONENTS RooFit RooStats)
@@ -41,16 +49,21 @@ add_subdirectory(CombinePdfs)
 
 add_library(CombineHarvester INTERFACE)
 target_include_directories(CombineHarvester INTERFACE
-  ${CMAKE_CURRENT_SOURCE_DIR}/CombineTools/interface
-  ${CMAKE_CURRENT_SOURCE_DIR}/CombinePdfs/interface
-  ${HiggsAnalysisCombinedLimit_INCLUDE_DIRS}
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/CombineTools/interface>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/CombinePdfs/interface>
+  $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(CombineHarvester INTERFACE CombineTools CombinePdfs ${HiggsAnalysisCombinedLimit_LIBRARIES})
+target_link_libraries(CombineHarvester INTERFACE
+  CombineTools
+  CombinePdfs
+  HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit)
 
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/HiggsAnalysis/CombinedLimit/interface/
-        DESTINATION include/HiggsAnalysis/CombinedLimit
-        FILES_MATCHING PATTERN "*.h" PATTERN "*.hh")
+if(NOT USE_SYSTEM_COMBINEDLIMIT)
+  install(DIRECTORY ${HiggsAnalysisCombinedLimit_SOURCE_DIR}/interface/
+          DESTINATION include/HiggsAnalysis/CombinedLimit
+          FILES_MATCHING PATTERN "*.h" PATTERN "*.hh")
+endif()
 
 install(TARGETS CombineHarvester EXPORT CombineHarvesterTargets)
 install(EXPORT CombineHarvesterTargets

--- a/CombinePdfs/CMakeLists.txt
+++ b/CombinePdfs/CMakeLists.txt
@@ -1,13 +1,18 @@
 file(GLOB COMBINE_PDFS_SRC src/*.cc)
 
 # Generate ROOT dictionary for classes in this package
-include_directories(interface ${CH_EXTERNAL_INCLUDES} ${ROOT_INCLUDE_DIRS})
+get_target_property(_CL_INC HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit INTERFACE_INCLUDE_DIRECTORIES)
+include_directories(interface ${CH_EXTERNAL_INCLUDES} ${ROOT_INCLUDE_DIRS} ${_CL_INC})
 ROOT_GENERATE_DICTIONARY(G__CombinePdfs src/classes.h LINKDEF src/classes_def.xml)
 
 add_library(CombinePdfs ${COMBINE_PDFS_SRC} ${CMAKE_CURRENT_BINARY_DIR}/G__CombinePdfs.cxx)
 
-target_include_directories(CombinePdfs PUBLIC interface ${CH_EXTERNAL_INCLUDES})
-target_link_libraries(CombinePdfs PUBLIC CombineTools ${CH_EXTERNAL_LIBS})
+target_include_directories(CombinePdfs PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/interface>
+  $<INSTALL_INTERFACE:include>
+  ${CH_EXTERNAL_INCLUDES}
+)
+target_link_libraries(CombinePdfs PUBLIC CombineTools ${CH_EXTERNAL_LIBS} HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit)
 set_target_properties(CombinePdfs PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 file(GLOB COMBINE_PDFS_BINS bin/*.cpp)

--- a/CombineTools/CMakeLists.txt
+++ b/CombineTools/CMakeLists.txt
@@ -1,13 +1,18 @@
 file(GLOB COMBINE_TOOLS_SRC src/*.cc)
 
 # Generate ROOT dictionary for classes in this package
-include_directories(interface ${CH_EXTERNAL_INCLUDES} ${ROOT_INCLUDE_DIRS})
+get_target_property(_CL_INC HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit INTERFACE_INCLUDE_DIRECTORIES)
+include_directories(interface ${CH_EXTERNAL_INCLUDES} ${ROOT_INCLUDE_DIRS} ${_CL_INC})
 ROOT_GENERATE_DICTIONARY(G__CombineTools src/classes.h LINKDEF src/classes_def.xml)
 
 add_library(CombineTools ${COMBINE_TOOLS_SRC} ${CMAKE_CURRENT_BINARY_DIR}/G__CombineTools.cxx)
 
-target_include_directories(CombineTools PUBLIC interface ${CH_EXTERNAL_INCLUDES})
-target_link_libraries(CombineTools PUBLIC ${CH_EXTERNAL_LIBS})
+target_include_directories(CombineTools PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/interface>
+  $<INSTALL_INTERFACE:include>
+  ${CH_EXTERNAL_INCLUDES}
+)
+target_link_libraries(CombineTools PUBLIC ${CH_EXTERNAL_LIBS} HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit)
 set_target_properties(CombineTools PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 file(GLOB COMBINE_TOOLS_BINS bin/*.cpp)

--- a/README.md
+++ b/README.md
@@ -14,13 +14,44 @@ full details.  A typical quick-start workflow is:
 ```
 git clone https://github.com/cms-analysis/CombineHarvester.git
 cd CombineHarvester
-git submodule update --init
 cmake -S . -B build
 cmake --build build --target install
 export CH_BASE=$(pwd)
 source build/setup.sh
 $CH_BASE/build/bin/Example1
 ```
+
+ The configure step will automatically download the
+ [`HiggsAnalysis/CombinedLimit`](https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit)
+ source if it is not present.
+
+If you already have `HiggsAnalysis/CombinedLimit` built and installed on your
+system, configure the build with
+
+```
+cmake -S . -B build -DUSE_SYSTEM_COMBINEDLIMIT=ON \
+      -DCMAKE_PREFIX_PATH=/path/to/combinedlimit
+```
+
+`find_package(HiggsAnalysisCombinedLimit)` will then locate the installation via
+`CMAKE_PREFIX_PATH`.
+When working from a source tree that was built using the repository `Makefile`
+instructions (for example cloned into `HiggsAnalysis/CombinedLimit` and built
+with `make`), point CMake to the checkout with
+
+```
+cmake -S . -B build -DUSE_SYSTEM_COMBINEDLIMIT=ON \
+      -DHiggsAnalysisCombinedLimit_ROOT=/path/to/HiggsAnalysis/CombinedLimit
+```
+
+You may also use the more explicit
+`-DHiggsAnalysisCombinedLimit_DIR=/path/to/combinedlimit/lib/cmake/HiggsAnalysisCombinedLimit`
+form. In this mode no download occurs and the headers and library from the
+existing build are used.
+
+If a build of `HiggsAnalysis/CombinedLimit` exists in a sibling directory named
+`../HiggsAnalysis/CombinedLimit`, the CMake configuration will automatically
+discover and use it when `-DUSE_SYSTEM_COMBINEDLIMIT=ON` is specified.
 
 The build requires several external C++ libraries: [ROOT](https://root.cern)
 (with the RooFit and RooStats components), Boost, libxml2, vdt and

--- a/cmake/FindHiggsAnalysisCombinedLimit.cmake
+++ b/cmake/FindHiggsAnalysisCombinedLimit.cmake
@@ -8,11 +8,45 @@
 # and defines an imported target
 #  HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit
 
+set(_HACL_HINTS "")
+if(DEFINED HiggsAnalysisCombinedLimit_ROOT)
+  list(APPEND _HACL_HINTS ${HiggsAnalysisCombinedLimit_ROOT})
+endif()
+if(DEFINED ENV{HiggsAnalysisCombinedLimit_ROOT})
+  list(APPEND _HACL_HINTS $ENV{HiggsAnalysisCombinedLimit_ROOT})
+endif()
+
+# Common checkout layout places the CombinedLimit repository as a sibling of
+# CombineHarvester:  ../HiggsAnalysis/CombinedLimit.  Fall back to searching
+# these locations (and their build directories) when the user does not provide
+# an explicit hint.
+get_filename_component(_hacl_module_dir "${CMAKE_CURRENT_LIST_DIR}" ABSOLUTE)
+list(APPEND _HACL_HINTS
+  "${_hacl_module_dir}/../HiggsAnalysis/CombinedLimit/build"
+  "${_hacl_module_dir}/../HiggsAnalysis/CombinedLimit"
+  "${_hacl_module_dir}/../../HiggsAnalysis/CombinedLimit/build"
+  "${_hacl_module_dir}/../../HiggsAnalysis/CombinedLimit")
+
+list(REMOVE_DUPLICATES _HACL_HINTS)
+
+# Search header hints in both the provided directories and their parents to
+# account for a source tree checked out as HiggsAnalysis/CombinedLimit.
+set(_HACL_HEADER_HINTS ${_HACL_HINTS})
+foreach(_dir IN LISTS _HACL_HINTS)
+  get_filename_component(_parent "${_dir}/.." ABSOLUTE)
+  list(APPEND _HACL_HEADER_HINTS ${_parent})
+endforeach()
+list(REMOVE_DUPLICATES _HACL_HEADER_HINTS)
+
 find_path(HiggsAnalysisCombinedLimit_INCLUDE_DIR
-          NAMES HiggsAnalysis/CombinedLimit/interface/Combine.h)
+          NAMES HiggsAnalysis/CombinedLimit/interface/Combine.h interface/Combine.h
+          HINTS ${_HACL_HEADER_HINTS}
+          PATH_SUFFIXES include .)
 
 find_library(HiggsAnalysisCombinedLimit_LIBRARY
-             NAMES HiggsAnalysisCombinedLimit)
+             NAMES HiggsAnalysisCombinedLimit
+             HINTS ${_HACL_HINTS}
+             PATH_SUFFIXES lib build/lib)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(

--- a/docs/StandaloneInstallation.md
+++ b/docs/StandaloneInstallation.md
@@ -20,8 +20,40 @@ ROOT installation if required.
 ```bash
 git clone https://github.com/cms-analysis/CombineHarvester.git
 cd CombineHarvester
-git submodule update --init
 ```
+
+The CMake build will automatically download the
+[HiggsAnalysis/CombinedLimit](https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit)
+sources if they are not already present.
+
+If you have `HiggsAnalysis/CombinedLimit` available as a separate installation,
+skip the download by configuring CombineHarvester with
+
+```bash
+cmake -S . -B build -DUSE_SYSTEM_COMBINEDLIMIT=ON \
+      -DCMAKE_PREFIX_PATH=/path/to/combinedlimit
+```
+
+`find_package(HiggsAnalysisCombinedLimit)` searches the locations listed in
+`CMAKE_PREFIX_PATH` for an installation that provides
+`HiggsAnalysisCombinedLimitConfig.cmake`.
+
+When working from a CombinedLimit source tree built with the provided
+`Makefile` (for example after running `make CONDA=1 -j8` in the
+`HiggsAnalysis/CombinedLimit` directory), point CMake to the checkout with
+
+```bash
+cmake -S . -B build -DUSE_SYSTEM_COMBINEDLIMIT=ON \
+      -DHiggsAnalysisCombinedLimit_ROOT=/path/to/HiggsAnalysis/CombinedLimit
+```
+
+so that the headers and library are picked up correctly. In all cases no
+download occurs and the build links against the existing library.
+
+If a build directory for `HiggsAnalysis/CombinedLimit` is present alongside the
+CombineHarvester source tree (for example `../HiggsAnalysis/CombinedLimit/build`),
+it will be detected automatically when configuring with
+`-DUSE_SYSTEM_COMBINEDLIMIT=ON`.
 
 ## Building with CMake
 


### PR DESCRIPTION
## Summary
- Improve HiggsAnalysis CombinedLimit detection by searching parent directories for headers, enabling use of Makefile-built repositories
- Document explicit configuration example for Makefile builds using `HiggsAnalysisCombinedLimit_ROOT`
- Export CombineTools/CombinePdfs headers via generator expressions to avoid CMake source-dir include errors

## Testing
- ❌ `cmake -S . -B build -DUSE_SYSTEM_COMBINEDLIMIT=ON -DHiggsAnalysisCombinedLimit_ROOT=/nonexistent` (Could NOT find HiggsAnalysisCombinedLimit)
- ⚠️ `cmake -S . -B build` (failed to clone HiggsAnalysis-CombinedLimit repository: CONNECT tunnel failed, response 403)


------
https://chatgpt.com/codex/tasks/task_e_68ba369f29348329b42dda8dd2019767