### PR TITLE
Use RooArgSet fwdIterator for parameter lookup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "HiggsAnalysis/CombinedLimit"]
+path = HiggsAnalysis/CombinedLimit
+url = https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git
+branch = main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,32 @@
 cmake_minimum_required(VERSION 3.12)
 project(CombineHarvester)
 
+# Ensure we build against the same C++ standard as ROOT to avoid
+# the "C++ standard ... does not match ROOT configuration" warning.
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 option(USE_SYSTEM_COMBINEDLIMIT "Use system-installed HiggsAnalysisCombinedLimit" OFF)
+set(COMBINEDLIMIT_TAG "main" CACHE STRING "Git branch or tag of HiggsAnalysis-CombinedLimit to fetch")
 
 if(USE_SYSTEM_COMBINEDLIMIT)
   find_package(HiggsAnalysisCombinedLimit REQUIRED)
 else()
-  if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/HiggsAnalysis/CombinedLimit/CMakeLists.txt")
-    message(FATAL_ERROR "HiggsAnalysis/CombinedLimit not found. Either enable USE_SYSTEM_COMBINEDLIMIT or fetch the sources as described in the README")
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/HiggsAnalysis/CombinedLimit/CMakeLists.txt")
+    add_subdirectory(HiggsAnalysis/CombinedLimit)
+    set(HiggsAnalysisCombinedLimit_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/HiggsAnalysis/CombinedLimit)
+  else()
+    include(FetchContent)
+    FetchContent_Declare(CombinedLimit
+      GIT_REPOSITORY https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git
+      GIT_TAG        ${COMBINEDLIMIT_TAG}
+    )
+    FetchContent_MakeAvailable(CombinedLimit)
+    set(HiggsAnalysisCombinedLimit_SOURCE_DIR ${combinedlimit_SOURCE_DIR})
   endif()
-  add_subdirectory(HiggsAnalysis/CombinedLimit)
-  set(HiggsAnalysisCombinedLimit_LIBRARIES HiggsAnalysisCombinedLimit)
-  set(HiggsAnalysisCombinedLimit_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/HiggsAnalysis/CombinedLimit/interface)
+  add_library(HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit ALIAS HiggsAnalysisCombinedLimit)
 endif()
 
 find_package(ROOT REQUIRED COMPONENTS RooFit RooStats)
@@ -41,16 +54,21 @@ add_subdirectory(CombinePdfs)
 
 add_library(CombineHarvester INTERFACE)
 target_include_directories(CombineHarvester INTERFACE
-  ${CMAKE_CURRENT_SOURCE_DIR}/CombineTools/interface
-  ${CMAKE_CURRENT_SOURCE_DIR}/CombinePdfs/interface
-  ${HiggsAnalysisCombinedLimit_INCLUDE_DIRS}
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/CombineTools/interface>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/CombinePdfs/interface>
+  $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(CombineHarvester INTERFACE CombineTools CombinePdfs ${HiggsAnalysisCombinedLimit_LIBRARIES})
+target_link_libraries(CombineHarvester INTERFACE
+  CombineTools
+  CombinePdfs
+  HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit)
 
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/HiggsAnalysis/CombinedLimit/interface/
-        DESTINATION include/HiggsAnalysis/CombinedLimit
-        FILES_MATCHING PATTERN "*.h" PATTERN "*.hh")
+if(NOT USE_SYSTEM_COMBINEDLIMIT)
+  install(DIRECTORY ${HiggsAnalysisCombinedLimit_SOURCE_DIR}/interface/
+          DESTINATION include/HiggsAnalysis/CombinedLimit
+          FILES_MATCHING PATTERN "*.h" PATTERN "*.hh")
+endif()
 
 install(TARGETS CombineHarvester EXPORT CombineHarvesterTargets)
 install(EXPORT CombineHarvesterTargets

--- a/CombineHarvester/CombinePdfs
+++ b/CombineHarvester/CombinePdfs
@@ -1,0 +1,1 @@
+../CombinePdfs

--- a/CombineHarvester/CombineTools
+++ b/CombineHarvester/CombineTools
@@ -1,0 +1,1 @@
+../CombineTools

--- a/CombinePdfs/CMakeLists.txt
+++ b/CombinePdfs/CMakeLists.txt
@@ -1,13 +1,21 @@
 file(GLOB COMBINE_PDFS_SRC src/*.cc)
 
-# Generate ROOT dictionary for classes in this package
-include_directories(interface ${CH_EXTERNAL_INCLUDES} ${ROOT_INCLUDE_DIRS})
-ROOT_GENERATE_DICTIONARY(G__CombinePdfs src/classes.h LINKDEF src/classes_def.xml)
+get_target_property(_CL_INC HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit INTERFACE_INCLUDE_DIRECTORIES)
 
-add_library(CombinePdfs ${COMBINE_PDFS_SRC} ${CMAKE_CURRENT_BINARY_DIR}/G__CombinePdfs.cxx)
+add_library(CombinePdfs ${COMBINE_PDFS_SRC})
 
-target_include_directories(CombinePdfs PUBLIC interface ${CH_EXTERNAL_INCLUDES})
-target_link_libraries(CombinePdfs PUBLIC CombineTools ${CH_EXTERNAL_LIBS})
+# Allow includes of the form
+#   "CombineHarvester/CombineTools/interface/..."
+# by exposing the repository root during the build.
+target_include_directories(CombinePdfs PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/interface>
+  $<INSTALL_INTERFACE:include>
+  ${CH_EXTERNAL_INCLUDES}
+  ${ROOT_INCLUDE_DIRS}
+  ${_CL_INC}
+)
+target_link_libraries(CombinePdfs PUBLIC CombineTools ${CH_EXTERNAL_LIBS} HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit)
 set_target_properties(CombinePdfs PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 file(GLOB COMBINE_PDFS_BINS bin/*.cpp)

--- a/CombineTools/CMakeLists.txt
+++ b/CombineTools/CMakeLists.txt
@@ -1,13 +1,23 @@
 file(GLOB COMBINE_TOOLS_SRC src/*.cc)
 
-# Generate ROOT dictionary for classes in this package
-include_directories(interface ${CH_EXTERNAL_INCLUDES} ${ROOT_INCLUDE_DIRS})
-ROOT_GENERATE_DICTIONARY(G__CombineTools src/classes.h LINKDEF src/classes_def.xml)
+get_target_property(_CL_INC HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit INTERFACE_INCLUDE_DIRECTORIES)
 
-add_library(CombineTools ${COMBINE_TOOLS_SRC} ${CMAKE_CURRENT_BINARY_DIR}/G__CombineTools.cxx)
+add_library(CombineTools ${COMBINE_TOOLS_SRC})
 
-target_include_directories(CombineTools PUBLIC interface ${CH_EXTERNAL_INCLUDES})
-target_link_libraries(CombineTools PUBLIC ${CH_EXTERNAL_LIBS})
+# Many sources include headers via the historic
+#   "CombineHarvester/CombineTools/interface/..." path.
+# Expose the repository root during the build so this
+# prefix resolves to the symlinked layout created in
+# the source tree.
+target_include_directories(CombineTools PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/interface>
+  $<INSTALL_INTERFACE:include>
+  ${CH_EXTERNAL_INCLUDES}
+  ${ROOT_INCLUDE_DIRS}
+  ${_CL_INC}
+)
+target_link_libraries(CombineTools PUBLIC ${CH_EXTERNAL_LIBS} HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit)
 set_target_properties(CombineTools PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 file(GLOB COMBINE_TOOLS_BINS bin/*.cpp)

--- a/CombineTools/src/Logging.cc
+++ b/CombineTools/src/Logging.cc
@@ -40,7 +40,7 @@ std::string FnError(std::string const& message, std::string const& file,
   res += "\n" + banner;
   res +=
       "\nPlease report issues at\n  "
-      "https://github.com/cms-analysis/CombineHarvester/issues";
+      "https://github.com/TheQuantiser/CustomCH/issues";
   res += "\n" + banner;
   return res;
 }

--- a/CombineTools/src/ParseCombineWorkspace.cc
+++ b/CombineTools/src/ParseCombineWorkspace.cc
@@ -1,5 +1,11 @@
 #include "CombineHarvester/CombineTools/interface/ParseCombineWorkspace.h"
+
+#if __has_include("HiggsAnalysis/CombinedLimit/interface/CMSHistErrorPropagator.h")
 #include "HiggsAnalysis/CombinedLimit/interface/CMSHistErrorPropagator.h"
+#define CH_HAS_CMSHISTERRORPROPAGATOR 1
+#else
+#define CH_HAS_CMSHISTERRORPROPAGATOR 0
+#endif
 #include <iostream>
 #include <string>
 #include <vector>
@@ -84,12 +90,14 @@ void ParseCombineWorkspace(CombineHarvester& cb, RooWorkspace& ws,
           throw std::runtime_error(FNERROR("This RooRealSumPdf is not extended!"));
         }
         if (pdfs->getSize() == 1) {
+#if CH_HAS_CMSHISTERRORPROPAGATOR
            CMSHistErrorPropagator *err = dynamic_cast<CMSHistErrorPropagator*>(pdfs->at(0));
            if (err) {
              coeffs = &(err->coefList());
              pdfs = new RooArgList(err->wrapperList());
              delete_pdfs = true;
            }
+#endif
         }
       }
       for (int j = 0; j < coeffs->getSize(); ++j) {

--- a/CombineTools/src/Utilities.cc
+++ b/CombineTools/src/Utilities.cc
@@ -5,12 +5,16 @@
 #include <string>
 #include <fstream>
 #include <map>
+#include <memory>
 #include "boost/format.hpp"
 #include "RooFitResult.h"
 #include "RooRealVar.h"
 #include "RooDataHist.h"
 #include "RooAbsReal.h"
 #include "RooAbsData.h"
+#include "RooArgSet.h"
+#include "RooArgList.h"
+#include "RooLinkedListIter.h"
 #include "CombineHarvester/CombineTools/interface/CombineHarvester.h"
 
 namespace ch {

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ See the [standalone installation guide](docs/StandaloneInstallation.md) for
 full details.  A typical quick-start workflow is:
 
 ```
-git clone https://github.com/cms-analysis/CombineHarvester.git
-cd CombineHarvester
+git clone https://github.com/TheQuantiser/CustomCH.git
+cd CustomCH
 git submodule update --init
 cmake -S . -B build
 cmake --build build --target install
@@ -21,6 +21,38 @@ export CH_BASE=$(pwd)
 source build/setup.sh
 $CH_BASE/build/bin/Example1
 ```
+
+The configure step will automatically download the
+[`HiggsAnalysis/CombinedLimit`](https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit)
+`main` branch source if it is not present.
+
+If you already have `HiggsAnalysis/CombinedLimit` built and installed on your
+system, configure the build with
+
+```
+cmake -S . -B build -DUSE_SYSTEM_COMBINEDLIMIT=ON \
+      -DCMAKE_PREFIX_PATH=/path/to/combinedlimit
+```
+
+`find_package(HiggsAnalysisCombinedLimit)` will then locate the installation via
+`CMAKE_PREFIX_PATH`.
+When working from a source tree that was built using the repository `Makefile`
+instructions (for example cloned into `HiggsAnalysis/CombinedLimit` and built
+with `make`), point CMake to the checkout with
+
+```
+cmake -S . -B build -DUSE_SYSTEM_COMBINEDLIMIT=ON \
+      -DHiggsAnalysisCombinedLimit_ROOT=/path/to/HiggsAnalysis/CombinedLimit
+```
+
+You may also use the more explicit
+`-DHiggsAnalysisCombinedLimit_DIR=/path/to/combinedlimit/lib/cmake/HiggsAnalysisCombinedLimit`
+form. In this mode no download occurs and the headers and library from the
+existing build are used.
+
+If a build of `HiggsAnalysis/CombinedLimit` exists in a sibling directory named
+`../HiggsAnalysis/CombinedLimit`, the CMake configuration will automatically
+discover and use it when `-DUSE_SYSTEM_COMBINEDLIMIT=ON` is specified.
 
 The build requires several external C++ libraries: [ROOT](https://root.cern)
 (with the RooFit and RooStats components), Boost, libxml2, vdt and

--- a/cmake/FindHiggsAnalysisCombinedLimit.cmake
+++ b/cmake/FindHiggsAnalysisCombinedLimit.cmake
@@ -8,11 +8,45 @@
 # and defines an imported target
 #  HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit
 
+set(_HACL_HINTS "")
+if(DEFINED HiggsAnalysisCombinedLimit_ROOT)
+  list(APPEND _HACL_HINTS ${HiggsAnalysisCombinedLimit_ROOT})
+endif()
+if(DEFINED ENV{HiggsAnalysisCombinedLimit_ROOT})
+  list(APPEND _HACL_HINTS $ENV{HiggsAnalysisCombinedLimit_ROOT})
+endif()
+
+# Common checkout layout places the CombinedLimit repository as a sibling of
+# CombineHarvester:  ../HiggsAnalysis/CombinedLimit.  Fall back to searching
+# these locations (and their build directories) when the user does not provide
+# an explicit hint.
+get_filename_component(_hacl_module_dir "${CMAKE_CURRENT_LIST_DIR}" ABSOLUTE)
+list(APPEND _HACL_HINTS
+  "${_hacl_module_dir}/../HiggsAnalysis/CombinedLimit/build"
+  "${_hacl_module_dir}/../HiggsAnalysis/CombinedLimit"
+  "${_hacl_module_dir}/../../HiggsAnalysis/CombinedLimit/build"
+  "${_hacl_module_dir}/../../HiggsAnalysis/CombinedLimit")
+
+list(REMOVE_DUPLICATES _HACL_HINTS)
+
+# Search header hints in both the provided directories and their parents to
+# account for a source tree checked out as HiggsAnalysis/CombinedLimit.
+set(_HACL_HEADER_HINTS ${_HACL_HINTS})
+foreach(_dir IN LISTS _HACL_HINTS)
+  get_filename_component(_parent "${_dir}/.." ABSOLUTE)
+  list(APPEND _HACL_HEADER_HINTS ${_parent})
+endforeach()
+list(REMOVE_DUPLICATES _HACL_HEADER_HINTS)
+
 find_path(HiggsAnalysisCombinedLimit_INCLUDE_DIR
-          NAMES HiggsAnalysis/CombinedLimit/interface/Combine.h)
+          NAMES HiggsAnalysis/CombinedLimit/interface/Combine.h interface/Combine.h
+          HINTS ${_HACL_HEADER_HINTS}
+          PATH_SUFFIXES include .)
 
 find_library(HiggsAnalysisCombinedLimit_LIBRARY
-             NAMES HiggsAnalysisCombinedLimit)
+             NAMES HiggsAnalysisCombinedLimit
+             HINTS ${_HACL_HINTS}
+             PATH_SUFFIXES lib build/lib)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
@@ -23,11 +57,25 @@ find_package_handle_standard_args(
 
 if(HiggsAnalysisCombinedLimit_FOUND)
   set(HiggsAnalysisCombinedLimit_LIBRARIES ${HiggsAnalysisCombinedLimit_LIBRARY})
-  set(HiggsAnalysisCombinedLimit_INCLUDE_DIRS ${HiggsAnalysisCombinedLimit_INCLUDE_DIR})
+  # Headers may be included with the prefix "HiggsAnalysis/CombinedLimit/".
+  # When the project is checked out as HiggsAnalysis/CombinedLimit, the
+  # include directory returned above is that repository root.  Expose the
+  # directory *above* "HiggsAnalysis" so the prefixed form resolves.  In the
+  # installed layout the include directory already points to the prefix root
+  # (e.g. /usr/include), so adding the parent is harmless.
+  get_filename_component(_HACL_PARENT "${HiggsAnalysisCombinedLimit_INCLUDE_DIR}/.." ABSOLUTE)
+  get_filename_component(_HACL_PARENT_NAME "${_HACL_PARENT}" NAME)
+  if(_HACL_PARENT_NAME STREQUAL "HiggsAnalysis")
+    get_filename_component(_HACL_PREFIX "${_HACL_PARENT}/.." ABSOLUTE)
+  else()
+    set(_HACL_PREFIX "${_HACL_PARENT}")
+  endif()
+  set(HiggsAnalysisCombinedLimit_INCLUDE_DIRS
+      "${_HACL_PREFIX};${HiggsAnalysisCombinedLimit_INCLUDE_DIR}")
   if(NOT TARGET HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit)
     add_library(HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit UNKNOWN IMPORTED)
     set_target_properties(HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit PROPERTIES
       IMPORTED_LOCATION "${HiggsAnalysisCombinedLimit_LIBRARY}"
-      INTERFACE_INCLUDE_DIRECTORIES "${HiggsAnalysisCombinedLimit_INCLUDE_DIR}")
+      INTERFACE_INCLUDE_DIRECTORIES "${HiggsAnalysisCombinedLimit_INCLUDE_DIRS}")
   endif()
 endif()

--- a/docs/Main.md
+++ b/docs/Main.md
@@ -69,7 +69,7 @@ A number of high-level tools have been developed to provide a more convenient in
 
 Other comments {#note}
 ======================
-**Creating a new package**: It is planned that each new analysis will create their own package within the `CombineHarvester` directory, where all the datacard creation, plotting and other tools specific to the analysis will be stored. This keeps the analysis-specific code self-contained, and ensures different analyses do not disrupt each other's workflow during the development phase. We expect that some tools or functions developed for specific analyses will be of more general use, in which case they will be promoted to the common `CombineTools` package. **Please raise an issue [here](https://github.com/cms-analysis/CombineHarvester/issues/new) if you would like a new package to be created for your analysis.**
+**Creating a new package**: It is planned that each new analysis will create their own package within the `CombineHarvester` directory, where all the datacard creation, plotting and other tools specific to the analysis will be stored. This keeps the analysis-specific code self-contained, and ensures different analyses do not disrupt each other's workflow during the development phase. We expect that some tools or functions developed for specific analyses will be of more general use, in which case they will be promoted to the common `CombineTools` package. **Please raise an issue [here](https://github.com/TheQuantiser/CustomCH/issues/new) if you would like a new package to be created for your analysis.**
 
 **Code developments**: New features and developments, or even just suggestions, are always welcome - either contact the developers directly or make a pull request.
 
@@ -85,7 +85,7 @@ Other comments {#note}
       Problem: TH1 eleTau_0jet_medium/ggH not found in $CH_BASE/auxiliaries/shapes/htt_et.inputs-sm-7TeV-hcg.root
     *******************************************************************************
 
-If the cause of such an error message is unclear, or if you believe the error message should not have been produced, please raise an issue here with full details on reproducing the problem: https://github.com/cms-analysis/CombineHarvester/issues/new
+If the cause of such an error message is unclear, or if you believe the error message should not have been produced, please raise an issue here with full details on reproducing the problem: https://github.com/TheQuantiser/CustomCH/issues/new
 
 Please also raise an issue if you encounter any bugs, unintended behaviour, abrupt errors or segmentation faults - these will be addressed promptly by the developers.
 

--- a/docs/StandaloneInstallation.md
+++ b/docs/StandaloneInstallation.md
@@ -18,10 +18,43 @@ ROOT installation if required.
 ## Repository setup
 
 ```bash
-git clone https://github.com/cms-analysis/CombineHarvester.git
-cd CombineHarvester
+git clone https://github.com/TheQuantiser/CustomCH.git
+cd CustomCH
 git submodule update --init
 ```
+
+The CMake build will automatically download the
+[HiggsAnalysis/CombinedLimit](https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit)
+`main` branch sources if they are not already present.
+
+If you have `HiggsAnalysis/CombinedLimit` available as a separate installation,
+skip the download by configuring CombineHarvester with
+
+```bash
+cmake -S . -B build -DUSE_SYSTEM_COMBINEDLIMIT=ON \
+      -DCMAKE_PREFIX_PATH=/path/to/combinedlimit
+```
+
+`find_package(HiggsAnalysisCombinedLimit)` searches the locations listed in
+`CMAKE_PREFIX_PATH` for an installation that provides
+`HiggsAnalysisCombinedLimitConfig.cmake`.
+
+When working from a CombinedLimit source tree built with the provided
+`Makefile` (for example after running `make CONDA=1 -j8` in the
+`HiggsAnalysis/CombinedLimit` directory), point CMake to the checkout with
+
+```bash
+cmake -S . -B build -DUSE_SYSTEM_COMBINEDLIMIT=ON \
+      -DHiggsAnalysisCombinedLimit_ROOT=/path/to/HiggsAnalysis/CombinedLimit
+```
+
+so that the headers and library are picked up correctly. In all cases no
+download occurs and the build links against the existing library.
+
+If a build directory for `HiggsAnalysis/CombinedLimit` is present alongside the
+CombineHarvester source tree (for example `../HiggsAnalysis/CombinedLimit/build`),
+it will be detected automatically when configuring with
+`-DUSE_SYSTEM_COMBINEDLIMIT=ON`.
 
 ## Building with CMake
 

--- a/docs/publish-doxygen.sh
+++ b/docs/publish-doxygen.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # Settings
-REPO_PATH=https://github.com/cms-analysis/CombineHarvester
+REPO_PATH=https://github.com/TheQuantiser/CustomCH
 HTML_PATH=docs/html
 COMMIT_USER="Documentation Builder"
 COMMIT_EMAIL="andrew.gilbert@cern.ch"
@@ -29,5 +29,5 @@ git add .
 git config user.name "${COMMIT_USER}"
 git config user.email "${COMMIT_EMAIL}"
 git commit -m "Automated documentation build for changeset ${CHANGESET}." || true
-git push https://${GITHUB_TOKEN}@github.com/cms-analysis/CombineHarvester gh-pages
+git push https://${GITHUB_TOKEN}@github.com/TheQuantiser/CustomCH gh-pages
 cd -


### PR DESCRIPTION
## Summary
- revert to RooArgSet::fwdIterator loops for parameter filtering
- include RooLinkedListIter header instead of TIterator

## Testing
- `cmake -S . -B build -DUSE_SYSTEM_COMBINEDLIMIT=ON -DHiggsAnalysisCombinedLimit_ROOT=/nonexistent -DCMAKE_PREFIX_PATH=$CONDA_PREFIX` (fails: Could NOT find HiggsAnalysisCombinedLimit)


------
https://chatgpt.com/codex/tasks/task_e_68ba369f29348329b42dda8dd2019767