### PR TITLE
Use forward iterators in Utilities

### DIFF
--- a/CombineTools/src/Utilities.cc
+++ b/CombineTools/src/Utilities.cc
@@ -26,17 +26,15 @@ RooArgSet ParametersByName(RooAbsReal const* pdf, RooArgSet const* dat_vars) {
   std::unique_ptr<RooArgSet> all_vars(pdf->getParameters(RooArgSet()));
   // Get the data variables and fill a set with all the names
   std::set<std::string> names;
-  std::unique_ptr<TIterator> dat_it(dat_vars->createIterator());
-  RooAbsArg *dat_arg = nullptr;
-  while ((dat_arg = static_cast<RooAbsArg *>(dat_it->Next()))) {
+  RooFIter dat_it = dat_vars->fwdIterator();
+  for (RooAbsArg* dat_arg = nullptr; (dat_arg = dat_it.next()); ) {
     names.insert(dat_arg->GetName());
   }
 
   // Build a new RooArgSet from all_vars, excluding any in names
   RooArgSet result_set;
-  std::unique_ptr<TIterator> vars_it(all_vars->createIterator());
-  RooAbsArg *vars_arg = nullptr;
-  while ((vars_arg = static_cast<RooAbsArg *>(vars_it->Next()))) {
+  RooFIter vars_it = all_vars->fwdIterator();
+  for (RooAbsArg* vars_arg = nullptr; (vars_arg = vars_it.next()); ) {
     if (!names.count(vars_arg->GetName())) {
       result_set.add(*vars_arg);
     }


### PR DESCRIPTION
## Summary
- include `RooArgSet` and `RooLinkedListIter`
- replace deprecated `createIterator` loops with `fwdIterator`

## Testing
- `cmake -S . -B build` *(fails: unable to clone HiggsAnalysis-CombinedLimit, CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0efca6d08329b3a42172c4e5a0bd