### PR TITLE
Auto-detect C++ standard from ROOT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ project(CombineHarvester)
 
 # Ensure we build against the same C++ standard as ROOT to avoid
 # the "C++ standard ... does not match ROOT configuration" warning.
-set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Default installation prefix: prefer an active Conda environment or the first
@@ -42,6 +41,33 @@ else()
 endif()
 
 find_package(ROOT REQUIRED COMPONENTS RooFitCore RooFit RooStats)
+
+# Query ROOT for the C++ standard to use
+set(_root_std "")
+if(DEFINED ROOT_CXX_STANDARD)
+  set(_root_std "${ROOT_CXX_STANDARD}")
+elseif(DEFINED ROOT_cxx_STANDARD)
+  set(_root_std "${ROOT_cxx_STANDARD}")
+else()
+  execute_process(COMMAND root-config --cflags
+                  OUTPUT_VARIABLE _root_cflags
+                  RESULT_VARIABLE _root_result
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(_root_result EQUAL 0)
+    string(REGEX MATCH "-std=c\+\+([0-9]+)" _match "${_root_cflags}")
+    if(_match)
+      set(_root_std "${CMAKE_MATCH_1}")
+    endif()
+  endif()
+endif()
+if(_root_std)
+  math(EXPR _root_std_int "${_root_std}")
+  set(CMAKE_CXX_STANDARD ${_root_std_int})
+else()
+  set(CMAKE_CXX_STANDARD 17)
+  message(WARNING "Could not detect C++ standard from ROOT. Falling back to C++17.")
+endif()
+
 find_package(Boost REQUIRED COMPONENTS program_options filesystem system)
 find_package(LibXml2 REQUIRED)
 find_package(vdt REQUIRED)


### PR DESCRIPTION
## Summary
- Query ROOT for its requested C++ standard and set CMAKE_CXX_STANDARD accordingly
- Fall back to C++17 with a warning if ROOT's standard cannot be determined

## Testing
- `cmake -S . -B build` *(fails: unable to clone HiggsAnalysis-CombinedLimit due to network restrictions)*
- `cmake -S . -B build -DUSE_SYSTEM_COMBINEDLIMIT=ON` *(fails: HiggsAnalysisCombinedLimit package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2a81640c8329addce9d2bdce77c2