### PR TITLE
Support shapeN systematic uncertainties

### DIFF
--- a/CombineTools/src/CombineHarvester_Datacards.cc
+++ b/CombineTools/src/CombineHarvester_Datacards.cc
@@ -509,7 +509,7 @@ int CombineHarvester::ParseDatacard(std::string const& filename,
         }
         sys->set_name(words[i][0]);
         std::string type = words[i][1];
-        if (!contains(std::vector<std::string> {"shape", "shape?", "shapeN2", "shapeU", "lnN", "lnU"},
+        if (!contains(std::vector<std::string> {"shape", "shape?", "shapeN", "shapeN2", "shapeU", "lnN", "lnU"},
                       type)) {
           throw std::runtime_error(
             FNERROR("Systematic type " + type + " not supported"));
@@ -533,8 +533,8 @@ int CombineHarvester::ParseDatacard(std::string const& filename,
           sys->set_value_u(boost::lexical_cast<double>(words[i][p]));
           sys->set_asymm(false);
         }
-        if (sys->type() == "shape" || sys->type() == "shapeN2" ||
-            sys->type() == "shapeU") {
+        if (sys->type() == "shape" || sys->type() == "shapeN" ||
+            sys->type() == "shapeN2" || sys->type() == "shapeU") {
           sys->set_scale(boost::lexical_cast<double>(words[i][p]));
           LoadShapes(sys.get(), hist_mapping);
         } else if (sys->type() == "shape?") {
@@ -554,8 +554,8 @@ int CombineHarvester::ParseDatacard(std::string const& filename,
             sys->set_scale(boost::lexical_cast<double>(words[i][p]));
           }
         }
-        if (sys->type() == "shape" || sys->type() == "shapeN2" ||
-            sys->type() == "shapeU")
+        if (sys->type() == "shape" || sys->type() == "shapeN" ||
+            sys->type() == "shapeN2" || sys->type() == "shapeU")
           sys->set_asymm(true);
 
         CombineHarvester::CreateParameterIfEmpty(sys->name());
@@ -1105,6 +1105,7 @@ void CombineHarvester::WriteDatacard(std::string const& name,
     bool seen_lnN = false;
     bool seen_lnU = false;
     bool seen_shape = false;
+    bool seen_shapeN = false;
     bool seen_shapeN2 = false;
     bool seen_shapeU = false;
     if (param_set.count(sys)) continue;
@@ -1124,8 +1125,9 @@ void CombineHarvester::WriteDatacard(std::string const& name,
             : (format("%g") % ptr->value_u()).str();
           break;
         }
-        if (tp == "shape" || tp == "shapeN2" || tp == "shapeU") {
+        if (tp == "shape" || tp == "shapeN" || tp == "shapeN2" || tp == "shapeU") {
           if (tp == "shape") seen_shape = true;
+          if (tp == "shapeN") seen_shapeN = true;
           if (tp == "shapeN2") seen_shapeN2 = true;
           if (tp == "shapeU") seen_shapeU = true;
           line[p + 2] = (format("%g") % ptr->scale()).str();
@@ -1157,6 +1159,8 @@ void CombineHarvester::WriteDatacard(std::string const& name,
     }
     if (seen_shapeN2) {
       line[1] = "shapeN2";
+    } else if (seen_shapeN) {
+      line[1] = "shapeN";
     } else if (seen_shapeU) {
       line[1] = "shapeU";
     } else if (seen_lnU) {


### PR DESCRIPTION
## Summary
- Accept `shapeN` as a valid systematic type during datacard parsing and load its up/down shapes.
- Track and write `shapeN` systematics when emitting datacards.

## Testing
- `python - <<'PY'
import CombineHarvester.CombineTools.ch as ch
harvester = ch.CombineHarvester()
harvester.ParseDatacard('sample_shapeN.txt')
harvester.WriteDatacard('sample_shapeN_out.txt','sample_shapeN.root')
print('done')
PY` *(fails: ModuleNotFoundError: No module named 'CombineHarvester.CombineTools.ch')*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7e1c3b90832985d4bf0515784d33