### PR TITLE
Use CMSHistErrorPropagator directly in workspace parser

### DIFF
--- a/CombineTools/src/ParseCombineWorkspace.cc
+++ b/CombineTools/src/ParseCombineWorkspace.cc
@@ -1,11 +1,6 @@
 #include "CombineHarvester/CombineTools/interface/ParseCombineWorkspace.h"
 
-#if __has_include("HiggsAnalysis/CombinedLimit/interface/CMSHistErrorPropagator.h")
 #include "HiggsAnalysis/CombinedLimit/interface/CMSHistErrorPropagator.h"
-#define CH_HAS_CMSHISTERRORPROPAGATOR 1
-#else
-#define CH_HAS_CMSHISTERRORPROPAGATOR 0
-#endif
 #include <iostream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
## Summary
- Always include CMSHistErrorPropagator when parsing workspaces
- Revert to CMSHistErrorPropagator wrapper list when RooRealSumPdf has a single component

## Testing
- `cmake -S . -B build` *(fails: CONNECT tunnel failed fetching HiggsAnalysis-CombinedLimit)*
- `ChronoSpectra --workspace combined_wspace.root --datacard combined.txt --output ChronoResult --storeSyst` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb91c406e4832986663024224a5f8a