### PR TITLE
Use CMSHistErrorPropagator directly in workspace parser

### DIFF
--- a/CombineTools/src/ParseCombineWorkspace.cc
+++ b/CombineTools/src/ParseCombineWorkspace.cc
@@ -1,11 +1,6 @@
 #include "CombineHarvester/CombineTools/interface/ParseCombineWorkspace.h"
 
-#if __has_include("HiggsAnalysis/CombinedLimit/interface/CMSHistErrorPropagator.h")
 #include "HiggsAnalysis/CombinedLimit/interface/CMSHistErrorPropagator.h"
-#define CH_HAS_CMSHISTERRORPROPAGATOR 1
-#else
-#define CH_HAS_CMSHISTERRORPROPAGATOR 0
-#endif
 #include <iostream>
 #include <string>
 #include <vector>
@@ -63,8 +58,6 @@ void ParseCombineWorkspace(CombineHarvester& cb, RooWorkspace& ws,
     obs.set_bin(cats.back());
     cb.InsertObservation(obs);
 
-    bool delete_pdfs = false;
-
     RooAbsReal *ipdf = FindAddPdf(pdf->getPdf(cats.back().c_str()));
     if (ipdf) {
       std::unique_ptr<RooArgSet> pdf_obs(ipdf->getObservables(data->get()));
@@ -94,8 +87,7 @@ void ParseCombineWorkspace(CombineHarvester& cb, RooWorkspace& ws,
               dynamic_cast<CMSHistErrorPropagator *>(pdfs->at(0));
           if (err) {
             coeffs = &(err->coefList());
-            pdfs = new RooArgList(err->wrapperList());
-            delete_pdfs = true;
+            pdfs = &(err->funcList());
           }
         }
       }
@@ -115,7 +107,6 @@ void ParseCombineWorkspace(CombineHarvester& cb, RooWorkspace& ws,
             {proc.bin(), proc.process(), jpdf->GetName(), jcoeff->GetName()});
         cb.InsertProcess(proc);
       }
-      if (delete_pdfs) delete pdfs;
     }
   }
   cb.AddWorkspace(ws);


### PR DESCRIPTION
## Summary
- When a RooRealSumPdf wraps a CMSHistErrorPropagator with a single entry, read coefficients and functions directly from the propagator instead of its wrappers
- Avoid temporary wrapper lists so each process keeps its original `combine.process` attribute

## Testing
- `cmake -S . -B build` *(fails: unable to clone HiggsAnalysis-CombinedLimit repository)*
- `ChronoSpectra --workspace combined_wspace.root --datacard combined.txt --output ChronoResult --storeSyst` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb91c406e4832986663024224a5f8a