### PR TITLE
Add CMake find modules for CombinedLimit, HistFactory and VDT

### DIFF
--- a/cmake/modules/FindHiggsAnalysisCombinedLimit.cmake
+++ b/cmake/modules/FindHiggsAnalysisCombinedLimit.cmake
@@ -1,0 +1,35 @@
+# - Find the HiggsAnalysis CombinedLimit library
+#
+# This module defines the following variables:
+#   HiggsAnalysisCombinedLimit_FOUND
+#   HiggsAnalysisCombinedLimit_INCLUDE_DIRS
+#   HiggsAnalysisCombinedLimit_LIBRARIES
+#
+# It also defines an imported target:
+#   HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit
+#
+# The search relies on CMAKE_PREFIX_PATH and standard system prefixes.
+
+find_path(HiggsAnalysisCombinedLimit_INCLUDE_DIR
+          NAMES HiggsAnalysis/CombinedLimit/interface/Combine.h interface/Combine.h
+          PATH_SUFFIXES include)
+
+find_library(HiggsAnalysisCombinedLimit_LIBRARY
+             NAMES HiggsAnalysisCombinedLimit
+             PATH_SUFFIXES lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  HiggsAnalysisCombinedLimit
+  REQUIRED_VARS HiggsAnalysisCombinedLimit_LIBRARY HiggsAnalysisCombinedLimit_INCLUDE_DIR)
+
+if(HiggsAnalysisCombinedLimit_FOUND)
+  set(HiggsAnalysisCombinedLimit_LIBRARIES ${HiggsAnalysisCombinedLimit_LIBRARY})
+  set(HiggsAnalysisCombinedLimit_INCLUDE_DIRS ${HiggsAnalysisCombinedLimit_INCLUDE_DIR})
+  if(NOT TARGET HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit)
+    add_library(HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit UNKNOWN IMPORTED)
+    set_target_properties(HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit PROPERTIES
+      IMPORTED_LOCATION "${HiggsAnalysisCombinedLimit_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${HiggsAnalysisCombinedLimit_INCLUDE_DIR}")
+  endif()
+endif()

--- a/cmake/modules/FindHistFactory.cmake
+++ b/cmake/modules/FindHistFactory.cmake
@@ -1,0 +1,35 @@
+# - Find the HistFactory library
+#
+# This module defines the following variables:
+#   HistFactory_FOUND
+#   HistFactory_INCLUDE_DIRS
+#   HistFactory_LIBRARIES
+#
+# It also defines an imported target:
+#   HistFactory::HistFactory
+#
+# The search relies on CMAKE_PREFIX_PATH and standard system prefixes.
+
+find_path(HistFactory_INCLUDE_DIR
+          NAMES RooStats/HistFactory/Measurement.h
+          PATH_SUFFIXES include)
+
+find_library(HistFactory_LIBRARY
+             NAMES HistFactory
+             PATH_SUFFIXES lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  HistFactory
+  REQUIRED_VARS HistFactory_LIBRARY HistFactory_INCLUDE_DIR)
+
+if(HistFactory_FOUND)
+  set(HistFactory_LIBRARIES ${HistFactory_LIBRARY})
+  set(HistFactory_INCLUDE_DIRS ${HistFactory_INCLUDE_DIR})
+  if(NOT TARGET HistFactory::HistFactory)
+    add_library(HistFactory::HistFactory UNKNOWN IMPORTED)
+    set_target_properties(HistFactory::HistFactory PROPERTIES
+      IMPORTED_LOCATION "${HistFactory_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${HistFactory_INCLUDE_DIR}")
+  endif()
+endif()

--- a/cmake/modules/FindVDT.cmake
+++ b/cmake/modules/FindVDT.cmake
@@ -1,0 +1,35 @@
+# - Find the VDT library
+#
+# This module defines the following variables:
+#   VDT_FOUND
+#   VDT_INCLUDE_DIRS
+#   VDT_LIBRARIES
+#
+# It also defines an imported target:
+#   VDT::VDT
+#
+# The search relies on CMAKE_PREFIX_PATH and standard system prefixes.
+
+find_path(VDT_INCLUDE_DIR
+          NAMES vdt/VDTMath.h vdt/vdtMath.h
+          PATH_SUFFIXES include)
+
+find_library(VDT_LIBRARY
+             NAMES VDT vdt
+             PATH_SUFFIXES lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  VDT
+  REQUIRED_VARS VDT_LIBRARY VDT_INCLUDE_DIR)
+
+if(VDT_FOUND)
+  set(VDT_LIBRARIES ${VDT_LIBRARY})
+  set(VDT_INCLUDE_DIRS ${VDT_INCLUDE_DIR})
+  if(NOT TARGET VDT::VDT)
+    add_library(VDT::VDT UNKNOWN IMPORTED)
+    set_target_properties(VDT::VDT PROPERTIES
+      IMPORTED_LOCATION "${VDT_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${VDT_INCLUDE_DIR}")
+  endif()
+endif()


### PR DESCRIPTION
## Summary
- add CMake find modules for HiggsAnalysis CombinedLimit, HistFactory and VDT

## Testing
- `cmake -S alt_ver -B build-test` *(fails: unable to clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bba16312ac8329af6a42df080c3647