### PR TITLE
Add path utilities for repository discovery

### DIFF
--- a/CombineTools/interface/PathTools.h
+++ b/CombineTools/interface/PathTools.h
@@ -1,0 +1,21 @@
+#ifndef CombineTools_PathTools_h
+#define CombineTools_PathTools_h
+#include <string>
+
+namespace ch {
+namespace paths {
+// Return the base directory of the CombineHarvester repository.
+// Uses the CH_BASE environment variable if set, otherwise attempts to
+// discover the location by searching upwards from the executable path.
+std::string base();
+
+// Path to the external auxiliaries directory. Can be overridden by the
+// CH_AUXILIARIES environment variable.
+std::string auxiliaries();
+
+// Path to the CombineTools input directory.
+std::string input();
+}  // namespace paths
+}  // namespace ch
+
+#endif

--- a/CombineTools/src/PathTools.cc
+++ b/CombineTools/src/PathTools.cc
@@ -1,0 +1,55 @@
+#include "CombineHarvester/CombineTools/interface/PathTools.h"
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+
+namespace ch {
+namespace paths {
+namespace fs = std::filesystem;
+
+// Helper function to search for the repository root starting from a path.
+static fs::path find_base(fs::path start) {
+  while (!start.empty()) {
+    if (fs::exists(start / "CombineTools") && fs::exists(start / "CombinePdfs")) {
+      return start;
+    }
+    auto parent = start.parent_path();
+    if (parent == start) break;
+    start = parent;
+  }
+  return {};
+}
+
+std::string base() {
+  static std::string cache = []() {
+    if (const char* env = std::getenv("CH_BASE")) {
+      return std::string(env);
+    }
+    fs::path exe;
+    try {
+      exe = fs::canonical("/proc/self/exe").parent_path();
+    } catch (fs::filesystem_error const&) {
+      exe = fs::current_path();
+    }
+    fs::path b = find_base(exe);
+    if (!b.empty()) return b.string();
+    b = find_base(fs::current_path());
+    if (!b.empty()) return b.string();
+    return std::string();
+  }();
+  return cache;
+}
+
+std::string auxiliaries() {
+  if (const char* env = std::getenv("CH_AUXILIARIES")) {
+    return std::string(env);
+  }
+  return (fs::path(base()) / "auxiliaries").string();
+}
+
+std::string input() {
+  return (fs::path(base()) / "CombineTools" / "input").string();
+}
+
+}  // namespace paths
+}  // namespace ch


### PR DESCRIPTION
## Summary
- Provide a new PathTools utility to locate the repository base, auxiliaries, and input directories.
- Detect CH_BASE and CH_AUXILIARIES environment overrides with std::filesystem fallbacks to executable paths.

## Testing
- `g++ -std=c++17 -c CombineTools/src/PathTools.cc -I .`


------
https://chatgpt.com/codex/tasks/task_e_68bba172d3a88329a44951fadc609ea1