### PR TITLE
Install CombineHarvester libraries and headers in namespaced directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,9 +119,9 @@ endif()
           NAMESPACE CombineHarvester::
           DESTINATION lib/cmake/CombineHarvester)
 
-  install(DIRECTORY CombineTools/interface/
+  install(DIRECTORY CombineTools/interface
           DESTINATION include/CombineHarvester/CombineTools
           FILES_MATCHING PATTERN "*.h" PATTERN "*.hh")
-  install(DIRECTORY CombinePdfs/interface/
+  install(DIRECTORY CombinePdfs/interface
           DESTINATION include/CombineHarvester/CombinePdfs
           FILES_MATCHING PATTERN "*.h" PATTERN "*.hh")

--- a/CombinePdfs/CMakeLists.txt
+++ b/CombinePdfs/CMakeLists.txt
@@ -32,4 +32,5 @@ install(TARGETS CombinePdfs ${COMBINE_PDFS_BINARIES}
   EXPORT CombineHarvesterTargets
   RUNTIME DESTINATION CombineHarvester/CombinePdfs
   LIBRARY DESTINATION CombineHarvester/CombinePdfs
-  ARCHIVE DESTINATION CombineHarvester/CombinePdfs)
+  ARCHIVE DESTINATION CombineHarvester/CombinePdfs
+  INCLUDES DESTINATION include)

--- a/CombineTools/CMakeLists.txt
+++ b/CombineTools/CMakeLists.txt
@@ -37,4 +37,5 @@ install(TARGETS CombineTools ${COMBINE_TOOLS_BINARIES}
   EXPORT CombineHarvesterTargets
   RUNTIME DESTINATION CombineHarvester/CombineTools
   LIBRARY DESTINATION CombineHarvester/CombineTools
-  ARCHIVE DESTINATION CombineHarvester/CombineTools)
+  ARCHIVE DESTINATION CombineHarvester/CombineTools
+  INCLUDES DESTINATION include)


### PR DESCRIPTION
## Summary
- Install CombineTools and CombinePdfs targets to `CombineHarvester/<module>` directories
- Export include directories and copy interface headers under `include/CombineHarvester`

## Testing
- `cmake -S . -B build` *(fails: unable to download HiggsAnalysis-CombinedLimit repository)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbb2d80f44832987ea79f92e56f15a