### PR TITLE
Switch to modern RooArgSet iteration

### DIFF
--- a/CombineTools/src/Utilities.cc
+++ b/CombineTools/src/Utilities.cc
@@ -5,6 +5,7 @@
 #include <string>
 #include <fstream>
 #include <map>
+#include <memory>
 #include "boost/format.hpp"
 #include "RooFitResult.h"
 #include "RooRealVar.h"
@@ -22,17 +23,13 @@ RooArgSet ParametersByName(RooAbsReal const* pdf, RooArgSet const* dat_vars) {
   std::unique_ptr<RooArgSet> all_vars(pdf->getParameters(RooArgSet()));
   // Get the data variables and fill a set with all the names
   std::set<std::string> names;
-  RooFIter dat_it = dat_vars->fwdIterator();
-  RooAbsArg *dat_arg = nullptr;
-  while ((dat_arg = dat_it.next())) {
+  for (auto* dat_arg : *dat_vars) {
     names.insert(dat_arg->GetName());
   }
 
   // Build a new RooArgSet from all_vars, excluding any in names
   RooArgSet result_set;
-  RooFIter vars_it = all_vars->fwdIterator();
-  RooAbsArg *vars_arg = nullptr;
-  while ((vars_arg = vars_it.next())) {
+  for (auto* vars_arg : *all_vars) {
     if (!names.count(vars_arg->GetName())) {
       result_set.add(*vars_arg);
     }


### PR DESCRIPTION
## Summary
- Replace deprecated RooArgSet::fwdIterator with range-based loops in ParametersByName
- Include `<memory>` to ensure unique_ptr support

## Testing
- `cmake -S . -B build` *(fails: cannot fetch HiggsAnalysis-CombinedLimit due to network 403)*
- `cmake -S . -B build -DUSE_SYSTEM_COMBINEDLIMIT=ON` *(fails: could not find HiggsAnalysisCombinedLimit)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb4213dd48329abaa681d88186ce8