### PR TITLE
feat: align CMake setup with alt version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,6 @@ set(CH_EXTERNAL_LIBS
   HistFactory::HistFactory
 )
 
-
 add_subdirectory(CombineTools)
 add_subdirectory(CombinePdfs)
 
@@ -112,16 +111,15 @@ if(NOT USE_SYSTEM_COMBINEDLIMIT)
           DESTINATION include/HiggsAnalysis/CombinedLimit
           FILES_MATCHING PATTERN "*.h" PATTERN "*.hh")
 endif()
+install(TARGETS CombineHarvester EXPORT CombineHarvesterTargets)
+install(EXPORT CombineHarvesterTargets
+        FILE CombineHarvesterTargets.cmake
+        NAMESPACE CombineHarvester::
+        DESTINATION lib/cmake/CombineHarvester)
 
-  install(TARGETS CombineHarvester EXPORT CombineHarvesterTargets)
-  install(EXPORT CombineHarvesterTargets
-          FILE CombineHarvesterTargets.cmake
-          NAMESPACE CombineHarvester::
-          DESTINATION lib/cmake/CombineHarvester)
-
-  install(DIRECTORY CombineTools/interface
-          DESTINATION include/CombineHarvester/CombineTools
-          FILES_MATCHING PATTERN "*.h" PATTERN "*.hh")
-  install(DIRECTORY CombinePdfs/interface
-          DESTINATION include/CombineHarvester/CombinePdfs
-          FILES_MATCHING PATTERN "*.h" PATTERN "*.hh")
+install(DIRECTORY CombineTools/interface
+        DESTINATION include/CombineHarvester/CombineTools
+        FILES_MATCHING PATTERN "*.h" PATTERN "*.hh")
+install(DIRECTORY CombinePdfs/interface
+        DESTINATION include/CombineHarvester/CombinePdfs
+        FILES_MATCHING PATTERN "*.h" PATTERN "*.hh")


### PR DESCRIPTION
## Summary
- ensure interface library `CombineHarvester` installs headers and targets cleanly
- standardize install section formatting

## Testing
- `cmake -S . -B build_new` *(fails: unable to clone HiggsAnalysis-CombinedLimit due to CONNECT tunnel 403)*
- `cmake -DUSE_SYSTEM_COMBINEDLIMIT=ON -S . -B build_new` *(fails: Could NOT find HiggsAnalysisCombinedLimit)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb4c9ce4083299fee75a474a08c6d