### PR TITLE
Use tabulate to print CLI options in table

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,11 @@ find_package(LibXml2 REQUIRED)
 find_package(vdt REQUIRED)
 find_package(HistFactory REQUIRED)
 
+# Header-only tabulate library
+add_library(tabulate INTERFACE)
+target_include_directories(tabulate INTERFACE
+  ${CMAKE_CURRENT_SOURCE_DIR}/extern/tabulate/include)
+
 set(CH_EXTERNAL_INCLUDES
   ${ROOT_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
@@ -89,6 +94,7 @@ set(CH_EXTERNAL_LIBS
   ${LIBXML2_LIBRARIES}
   vdt::vdt
   HistFactory::HistFactory
+  tabulate
 )
 
 add_subdirectory(CombineTools)

--- a/CombineTools/src/cli.cpp
+++ b/CombineTools/src/cli.cpp
@@ -4,6 +4,7 @@
 #include <boost/program_options.hpp>
 #include <boost/any.hpp>
 #include <iostream>
+#include <tabulate/table.hpp>
 
 ChronoSpectraConfig parseCommandLine(int argc, char *argv[]) {
   ChronoSpectraConfig cfg;
@@ -107,29 +108,32 @@ ChronoSpectraConfig parseCommandLine(int argc, char *argv[]) {
   }
 
   std::cout << "\n\nUsing option values:" << std::endl;
+  tabulate::Table table;
+  table.add_row({"Option", "Value"});
   for (const auto &option : config.options()) {
     const std::string &name = option->long_name();
-    std::cout << "--" << name << ": ";
+    std::string value_str;
     if (vm.count(name)) {
       try {
         auto value = vm[name].value();
         if (value.type() == typeid(std::string)) {
-          std::cout << boost::any_cast<std::string>(value);
+          value_str = boost::any_cast<std::string>(value);
         } else if (value.type() == typeid(bool)) {
-          std::cout << (boost::any_cast<bool>(value) ? "true" : "false");
+          value_str = boost::any_cast<bool>(value) ? "true" : "false";
         } else if (value.type() == typeid(unsigned)) {
-          std::cout << boost::any_cast<unsigned>(value);
+          value_str = std::to_string(boost::any_cast<unsigned>(value));
         } else {
-          std::cout << "unknown value type";
+          value_str = "unknown value type";
         }
       } catch (const boost::bad_any_cast &) {
-        std::cout << "Error casting value";
+        value_str = "Error casting value";
       }
     } else {
-      std::cout << "not set";
+      value_str = "not set";
     }
-    std::cout << std::endl;
+    table.add_row({"--" + name, value_str});
   }
+  std::cout << table << std::endl;
   std::cout << "\n\n";
 
   return cfg;

--- a/extern/tabulate/include/tabulate/table.hpp
+++ b/extern/tabulate/include/tabulate/table.hpp
@@ -1,0 +1,47 @@
+#pragma once
+#include <algorithm>
+#include <initializer_list>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace tabulate {
+
+class Table {
+ public:
+  using Row = std::vector<std::string>;
+
+  void add_row(const std::initializer_list<std::string> &row) {
+    rows_.emplace_back(row);
+  }
+
+  void add_row(const Row &row) { rows_.push_back(row); }
+
+  friend std::ostream &operator<<(std::ostream &os, const Table &table) {
+    if (table.rows_.empty()) return os;
+    std::size_t cols = 0;
+    for (const auto &row : table.rows_) cols = std::max(cols, row.size());
+    std::vector<std::size_t> widths(cols, 0);
+    for (const auto &row : table.rows_) {
+      for (std::size_t c = 0; c < row.size(); ++c) {
+        widths[c] = std::max(widths[c], row[c].size());
+      }
+    }
+    for (std::size_t r = 0; r < table.rows_.size(); ++r) {
+      const auto &row = table.rows_[r];
+      for (std::size_t c = 0; c < cols; ++c) {
+        const std::string &cell = c < row.size() ? row[c] : std::string();
+        os << std::left << std::setw(static_cast<int>(widths[c] + 2)) << cell;
+      }
+      if (r + 1 != table.rows_.size()) os << '\n';
+    }
+    return os;
+  }
+
+ private:
+  std::vector<Row> rows_;
+};
+
+}  // namespace tabulate
+


### PR DESCRIPTION
## Summary
- bundle lightweight header-only tabulate library and expose via CMake
- show parsed ChronoSpectra options in a tabulated format

## Testing
- `cmake -S . -B build_tabulate` *(fails: unable to fetch HiggsAnalysis-CombinedLimit)*
- `g++ -std=c++17 /tmp/cli_test.cpp CombineTools/src/cli.cpp -I. -Iextern/tabulate/include -lboost_program_options -o /tmp/cli_test` *(fails: boost/algorithm/string.hpp: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68bbc704b2e0832993f299fc5e455794