### PR TITLE
Document how to provide CombinedLimit dependency

### DIFF
--- a/CombinePdfs/CMakeLists.txt
+++ b/CombinePdfs/CMakeLists.txt
@@ -30,7 +30,7 @@ endforeach()
 
 install(TARGETS CombinePdfs ${COMBINE_PDFS_BINARIES}
   EXPORT CombineHarvesterTargets
-  RUNTIME DESTINATION CombineHarvester/CombinePdfs
-  LIBRARY DESTINATION CombineHarvester/CombinePdfs
-  ARCHIVE DESTINATION CombineHarvester/CombinePdfs
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
   INCLUDES DESTINATION include)

--- a/CombineTools/CMakeLists.txt
+++ b/CombineTools/CMakeLists.txt
@@ -35,7 +35,7 @@ endforeach()
 
 install(TARGETS CombineTools ${COMBINE_TOOLS_BINARIES}
   EXPORT CombineHarvesterTargets
-  RUNTIME DESTINATION CombineHarvester/CombineTools
-  LIBRARY DESTINATION CombineHarvester/CombineTools
-  ARCHIVE DESTINATION CombineHarvester/CombineTools
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
   INCLUDES DESTINATION include)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Full documentation: http://cms-analysis.github.io/CombineHarvester
 CombineHarvester can be built as a standalone project using CMake. The
 build system will automatically fetch the required
 `HiggsAnalysis/CombinedLimit` dependency if it is not already present.
+On networks where outbound access is blocked the dependency must be
+cloned manually or provided via the `USE_SYSTEM_COMBINEDLIMIT` option.
 A minimal build looks like:
 
 ```bash
@@ -16,6 +18,9 @@ cmake -S . -B build
 cmake --build build -j$(nproc)
 cmake --install build
 ```
+
+This installs the command-line tools into the `bin` directory of the
+selected prefix.
 
 See [docs/StandaloneInstallation.md](docs/StandaloneInstallation.md) for
 more details on dependency setup and optional Conda environments. The

--- a/docs/StandaloneInstallation.md
+++ b/docs/StandaloneInstallation.md
@@ -15,6 +15,22 @@ packages:
 * LibXml2
 * VDT
 * HistFactory
+* [HiggsAnalysis-CombinedLimit](https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit)
+
+The `HiggsAnalysis-CombinedLimit` dependency is required because
+`CombineHarvester` links against the `libHiggsAnalysisCombinedLimit`
+library.  During configuration CMake will attempt to download this
+package automatically using `FetchContent`.  If the download is not
+possible (for example on networks without direct internet access), clone
+the dependency by hand before running CMake:
+
+```bash
+git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
+```
+
+Alternatively an already installed version can be used by enabling the
+`USE_SYSTEM_COMBINEDLIMIT` option and pointing CMake to its location via
+`-DHiggsAnalysisCombinedLimit_DIR=/path/to/lib/cmake/HiggsAnalysisCombinedLimit`.
 
 These packages can be provided by the host system or through a Conda
 environment (see below).
@@ -51,4 +67,8 @@ desired.
 After installation the libraries and Python bindings are available from
 the chosen prefix and `CombineHarvester` can be used like any other
 installed package.
+
+Command-line tools such as `ChronoSpectra` are installed into the `bin`
+directory of that prefix, which is typically added to the `PATH` by
+Conda environments.
 


### PR DESCRIPTION
## Summary
- Install CombineHarvester tools into the standard `bin` directory
- Document location of installed command-line tools alongside the CombinedLimit dependency notes

## Testing
- `cmake -S . -B build` *(fails: unable to download HiggsAnalysis-CombinedLimit)*


------
https://chatgpt.com/codex/tasks/task_e_68bbcfbef2088329a2ad3f181ea7ea50