### PR TITLE
Refresh build scripts after example removal

### DIFF
--- a/CombinePdfs/CMakeLists.txt
+++ b/CombinePdfs/CMakeLists.txt
@@ -1,4 +1,4 @@
-file(GLOB COMBINE_PDFS_SRC src/*.cc)
+file(GLOB CONFIGURE_DEPENDS COMBINE_PDFS_SRC src/*.cc)
 
 get_target_property(_CL_INC HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit INTERFACE_INCLUDE_DIRECTORIES)
 
@@ -19,7 +19,7 @@ target_include_directories(CombinePdfs PUBLIC
 target_link_libraries(CombinePdfs PUBLIC CombineTools ${CH_EXTERNAL_LIBS} HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit)
 set_target_properties(CombinePdfs PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-file(GLOB COMBINE_PDFS_BINS bin/*.cpp)
+file(GLOB CONFIGURE_DEPENDS COMBINE_PDFS_BINS bin/*.cpp)
 set(COMBINE_PDFS_BINARIES)
 foreach(src ${COMBINE_PDFS_BINS})
   get_filename_component(name ${src} NAME_WE)

--- a/CombineTools/CMakeLists.txt
+++ b/CombineTools/CMakeLists.txt
@@ -1,4 +1,4 @@
-file(GLOB COMBINE_TOOLS_SRC src/*.cc src/*.cpp)
+file(GLOB CONFIGURE_DEPENDS COMBINE_TOOLS_SRC src/*.cc src/*.cpp)
 
 get_target_property(_CL_INC HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit INTERFACE_INCLUDE_DIRECTORIES)
 
@@ -22,7 +22,7 @@ target_include_directories(CombineTools PUBLIC
 target_link_libraries(CombineTools PUBLIC ${CH_EXTERNAL_LIBS} HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit)
 set_target_properties(CombineTools PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-file(GLOB COMBINE_TOOLS_BINS bin/*.cpp)
+file(GLOB CONFIGURE_DEPENDS COMBINE_TOOLS_BINS bin/*.cpp)
 set(COMBINE_TOOLS_BINARIES)
 foreach(src ${COMBINE_TOOLS_BINS})
   get_filename_component(name ${src} NAME_WE)


### PR DESCRIPTION
## Summary
- rerun globbing with CONFIGURE_DEPENDS so build files update when sources are added or removed

## Testing
- `cmake -S . -B build` *(fails: unable to clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git: CONNECT tunnel failed 403)*
- `cmake -S . -B build -DUSE_SYSTEM_COMBINEDLIMIT=ON` *(fails: Could NOT find HiggsAnalysisCombinedLimit)*


------
https://chatgpt.com/codex/tasks/task_e_68bbe0f662148329832beeed37c4e48d