### PR TITLE
Fix scikit-build configuration for editable installs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.15)
 project(CombineHarvester)
 
 # Ensure we build against the same C++ standard as ROOT to avoid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,5 +52,6 @@ include-package-data = true
 "CombineHarvester.CombineTools.input.xsecs_brs" = ["*"]
 
 [tool.scikit-build]
-cmake.install-dir = ""
+wheel.install-dir = ""
+cmake.minimum-version = "3.15"
 


### PR DESCRIPTION
## Summary
- use supported `wheel.install-dir` option for scikit-build
- require CMake ≥3.15 to match scikit-build-core expectations

## Testing
- ⚠️ `pip install -e .` *(failed: Could not find a version that satisfies the requirement scikit-build-core)*

------
https://chatgpt.com/codex/tasks/task_e_68bbec1c2fb48329a79e751143e0efd8