### PR TITLE
Fix scikit-build configuration for editable installs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.15)
 project(CombineHarvester)
 
 # Ensure we build against the same C++ standard as ROOT to avoid
@@ -114,6 +114,7 @@ target_link_libraries(CombineHarvester INTERFACE
   HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit)
 
 if(NOT USE_SYSTEM_COMBINEDLIMIT)
+  install(TARGETS HiggsAnalysisCombinedLimit EXPORT CombineHarvesterTargets)
   install(DIRECTORY ${HiggsAnalysisCombinedLimit_SOURCE_DIR}/interface/
           DESTINATION include/HiggsAnalysis/CombinedLimit
           FILES_MATCHING PATTERN "*.h" PATTERN "*.hh")

--- a/CombineTools/CMakeLists.txt
+++ b/CombineTools/CMakeLists.txt
@@ -1,6 +1,9 @@
 file(GLOB COMBINE_TOOLS_SRC CONFIGURE_DEPENDS src/*.cc src/*.cpp)
 
 get_target_property(_CL_INC HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit INTERFACE_INCLUDE_DIRECTORIES)
+if(NOT _CL_INC AND DEFINED HiggsAnalysisCombinedLimit_SOURCE_DIR)
+  set(_CL_INC "${HiggsAnalysisCombinedLimit_SOURCE_DIR}/interface")
+endif()
 
 # Build a shared library so that ROOT and CombinedLimit
 # dependencies are linked once and reused by all executables.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,5 +52,6 @@ include-package-data = true
 "CombineHarvester.CombineTools.input.xsecs_brs" = ["*"]
 
 [tool.scikit-build]
-cmake.install-dir = ""
+wheel.install-dir = ""
+cmake.minimum-version = "3.15"
 


### PR DESCRIPTION
## Summary
- use supported `wheel.install-dir` option for scikit-build
- require CMake ≥3.15 to match scikit-build-core expectations
- export `HiggsAnalysisCombinedLimit` and provide fallback include path so CMake configure succeeds

## Testing
- ⚠️ `pip install -e .` *(failed: Could not find a version that satisfies the requirement scikit-build-core)*

------
https://chatgpt.com/codex/tasks/task_e_68bbec1c2fb48329a79e751143e0efd8