### PR TITLE
Refine CombineTools include directories

### DIFF
--- a/CombineTools/CMakeLists.txt
+++ b/CombineTools/CMakeLists.txt
@@ -14,13 +14,15 @@ add_library(CombineTools SHARED ${COMBINE_TOOLS_SRC})
 # Expose the repository root during the build so this
 # prefix resolves to the symlinked layout created in
 # the source tree.
-target_include_directories(CombineTools PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/interface>
-  $<INSTALL_INTERFACE:include>
-  ${CH_EXTERNAL_INCLUDES}
-  ${ROOT_INCLUDE_DIRS}
-  ${_CL_INC}
+target_include_directories(CombineTools
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/interface>
+    $<INSTALL_INTERFACE:include>
+  PRIVATE
+    ${CH_EXTERNAL_INCLUDES}
+    ${ROOT_INCLUDE_DIRS}
+    ${_CL_INC}
 )
 target_link_libraries(CombineTools PUBLIC ${CH_EXTERNAL_LIBS} HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit)
 set_target_properties(CombineTools PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
## Summary
- avoid leaking external include directories from CombineTools installation
- restrict install interface to installed headers only

## Testing
- `cmake -S . -B build` *(fails: unable to clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git, CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf0d23ad08329b0cf00403f669b4e