### PR TITLE
Use setuptools CMake build for Python package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [build-system]
-requires = ["scikit-build-core", "setuptools>=61", "wheel", "cmake", "ninja"]
-build-backend = "scikit_build_core.build"
+requires = ["setuptools>=61", "wheel", "cmake", "ninja"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "combineharvester"
 version = "0.1.0"
 description = "CMS CombineHarvester tools"
 readme = "README.md"
-authors = [{ name = "CMS" }]
+authors = [{name = "CMS"}]
 requires-python = ">=3.8"
 dependencies = [
     "numpy",
@@ -29,19 +29,20 @@ packages = [
     "CombineHarvester.CombineTools.input.examples",
     "CombineHarvester.CombineTools.input.job_prefixes",
     "CombineHarvester.CombineTools.input.xsecs_brs",
+    "CombineHarvester.CombinePdfs",
 ]
-include-package-data = true
 
 [tool.setuptools.package-dir]
 "CombineHarvester" = "CombineHarvester"
-"CombineHarvester.CombineTools" = "CombineTools/python"
-"CombineHarvester.CombineTools.combine" = "CombineTools/python/combine"
-"CombineHarvester.CombineTools.systematics" = "CombineTools/python/systematics"
-"CombineHarvester.CombineTools.scripts" = "CombineTools/scripts"
-"CombineHarvester.CombineTools.input" = "CombineTools/input"
-"CombineHarvester.CombineTools.input.examples" = "CombineTools/input/examples"
-"CombineHarvester.CombineTools.input.job_prefixes" = "CombineTools/input/job_prefixes"
-"CombineHarvester.CombineTools.input.xsecs_brs" = "CombineTools/input/xsecs_brs"
+"CombineHarvester.CombineTools" = "CombineHarvester/CombineTools/python"
+"CombineHarvester.CombineTools.combine" = "CombineHarvester/CombineTools/python/combine"
+"CombineHarvester.CombineTools.systematics" = "CombineHarvester/CombineTools/python/systematics"
+"CombineHarvester.CombineTools.scripts" = "CombineHarvester/CombineTools/scripts"
+"CombineHarvester.CombineTools.input" = "CombineHarvester/CombineTools/input"
+"CombineHarvester.CombineTools.input.examples" = "CombineHarvester/CombineTools/input/examples"
+"CombineHarvester.CombineTools.input.job_prefixes" = "CombineHarvester/CombineTools/input/job_prefixes"
+"CombineHarvester.CombineTools.input.xsecs_brs" = "CombineHarvester/CombineTools/input/xsecs_brs"
+"CombineHarvester.CombinePdfs" = "CombineHarvester/CombinePdfs/python"
 
 [tool.setuptools.package-data]
 "CombineHarvester.CombineTools" = ["*.so"]
@@ -50,8 +51,5 @@ include-package-data = true
 "CombineHarvester.CombineTools.input.examples" = ["*"]
 "CombineHarvester.CombineTools.input.job_prefixes" = ["*"]
 "CombineHarvester.CombineTools.input.xsecs_brs" = ["*"]
-
-[tool.scikit-build]
-wheel.install-dir = ""
-cmake.minimum-version = "3.15"
+"CombineHarvester.CombinePdfs" = ["*.so"]
 


### PR DESCRIPTION
## Summary
- replace scikit-build-core with setuptools.build_meta
- map Python packages and data directories, including CombinePdfs
- add CMake-based build_ext to compile and install C++ libs
- correct package directory paths to reside under CombineHarvester tree

## Testing
- `python -m pip install -e . --no-build-isolation -v` *(fails: Cannot import `setuptools.build_meta`)*
- `python setup.py build_ext -v` *(fails: ModuleNotFoundError: No module named 'setuptools')*

------
https://chatgpt.com/codex/tasks/task_e_68bbf1f17468832996f905e63336f670