### PR TITLE
Use setuptools CMake build for Python package

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ cmake --install build
 This installs the command-line tools into the `bin` directory of the
 selected prefix.
 
+## Python package
+
+The Python bindings can be installed in editable mode. This will invoke
+the CMake build to compile the C++ libraries and copy them into the
+installed package:
+
+```bash
+python -m pip install -e .
+```
+
 See [docs/StandaloneInstallation.md](docs/StandaloneInstallation.md) for
 more details on dependency setup and optional Conda environments. The
 current recommended tag is `v3.0.0-pre1`.

--- a/docs/StandaloneInstallation.md
+++ b/docs/StandaloneInstallation.md
@@ -68,6 +68,16 @@ After installation the libraries and Python bindings are available from
 the chosen prefix and `CombineHarvester` can be used like any other
 installed package.
 
+## Installing the Python package
+
+Instead of a full install, the Python bindings can be built directly in
+editable mode. This will run CMake to compile the C++ libraries and place
+them into the Python package:
+
+```bash
+python -m pip install -e .
+```
+
 Command-line tools such as `ChronoSpectra` are installed into the `bin`
 directory of that prefix, which is typically added to the `PATH` by
 Conda environments.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [build-system]
-requires = ["scikit-build-core", "setuptools>=61", "wheel", "cmake", "ninja"]
-build-backend = "scikit_build_core.build"
+requires = ["setuptools>=61", "wheel", "cmake", "ninja"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "combineharvester"
 version = "0.1.0"
 description = "CMS CombineHarvester tools"
 readme = "README.md"
-authors = [{ name = "CMS" }]
+authors = [{name = "CMS"}]
 requires-python = ">=3.8"
 dependencies = [
     "numpy",
@@ -29,8 +29,8 @@ packages = [
     "CombineHarvester.CombineTools.input.examples",
     "CombineHarvester.CombineTools.input.job_prefixes",
     "CombineHarvester.CombineTools.input.xsecs_brs",
+    "CombineHarvester.CombinePdfs",
 ]
-include-package-data = true
 
 [tool.setuptools.package-dir]
 "CombineHarvester" = "CombineHarvester"
@@ -42,6 +42,7 @@ include-package-data = true
 "CombineHarvester.CombineTools.input.examples" = "CombineTools/input/examples"
 "CombineHarvester.CombineTools.input.job_prefixes" = "CombineTools/input/job_prefixes"
 "CombineHarvester.CombineTools.input.xsecs_brs" = "CombineTools/input/xsecs_brs"
+"CombineHarvester.CombinePdfs" = "CombinePdfs/python"
 
 [tool.setuptools.package-data]
 "CombineHarvester.CombineTools" = ["*.so"]
@@ -50,8 +51,5 @@ include-package-data = true
 "CombineHarvester.CombineTools.input.examples" = ["*"]
 "CombineHarvester.CombineTools.input.job_prefixes" = ["*"]
 "CombineHarvester.CombineTools.input.xsecs_brs" = ["*"]
-
-[tool.scikit-build]
-wheel.install-dir = ""
-cmake.minimum-version = "3.15"
+"CombineHarvester.CombinePdfs" = ["*.so"]
 


### PR DESCRIPTION
## Summary
- map Python package directories from `CombineTools` and `CombinePdfs` directly to their source trees
- document editable `pip install` that builds the C++ libraries with CMake

## Testing
- `python -m pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `python -m pip install -e . --no-build-isolation -v` *(fails: BackendUnavailable: Cannot import 'setuptools.build_meta')*
- `python setup.py build_ext -v` *(fails: ModuleNotFoundError: No module named 'setuptools')*

------
https://chatgpt.com/codex/tasks/task_e_68bbf1f17468832996f905e63336f670