### PR TITLE
Remove CombinePdfs packaging

### DIFF
--- a/CombineHarvester/CombinePdfs
+++ b/CombineHarvester/CombinePdfs
@@ -1,1 +1,0 @@
-../CombinePdfs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ packages = [
     "CombineHarvester.CombineTools.input.examples",
     "CombineHarvester.CombineTools.input.job_prefixes",
     "CombineHarvester.CombineTools.input.xsecs_brs",
-    "CombineHarvester.CombinePdfs",
 ]
 
 [tool.setuptools.package-dir]
@@ -42,7 +41,6 @@ packages = [
 "CombineHarvester.CombineTools.input.examples" = "CombineHarvester/CombineTools/input/examples"
 "CombineHarvester.CombineTools.input.job_prefixes" = "CombineHarvester/CombineTools/input/job_prefixes"
 "CombineHarvester.CombineTools.input.xsecs_brs" = "CombineHarvester/CombineTools/input/xsecs_brs"
-"CombineHarvester.CombinePdfs" = "CombineHarvester/CombinePdfs/python"
 
 [tool.setuptools.package-data]
 "CombineHarvester.CombineTools" = ["*.so"]
@@ -51,5 +49,4 @@ packages = [
 "CombineHarvester.CombineTools.input.examples" = ["*"]
 "CombineHarvester.CombineTools.input.job_prefixes" = ["*"]
 "CombineHarvester.CombineTools.input.xsecs_brs" = ["*"]
-"CombineHarvester.CombinePdfs" = ["*.so"]
 

--- a/setup.py
+++ b/setup.py
@@ -14,16 +14,12 @@ class CMakeBuild(build_ext):
         build_temp.mkdir(parents=True, exist_ok=True)
         source_dir = Path(__file__).resolve().parent
         subprocess.check_call(["cmake", "-S", str(source_dir), "-B", str(build_temp)])
-        subprocess.check_call(["cmake", "--build", str(build_temp), "--target", "CombineTools", "CombinePdfs"])
+        subprocess.check_call(["cmake", "--build", str(build_temp), "--target", "CombineTools"])
         suffix = ".dll" if sys.platform == "win32" else (".dylib" if sys.platform == "darwin" else ".so")
         dest_tools = Path(self.build_lib) / "CombineHarvester" / "CombineTools"
-        dest_pdfs = Path(self.build_lib) / "CombineHarvester" / "CombinePdfs"
         dest_tools.mkdir(parents=True, exist_ok=True)
-        dest_pdfs.mkdir(parents=True, exist_ok=True)
         shutil.copy2(build_temp / "CombineTools" / f"libCombineTools{suffix}",
                      dest_tools / f"libCombineHarvesterCombineTools{suffix}")
-        shutil.copy2(build_temp / "CombinePdfs" / f"libCombinePdfs{suffix}",
-                     dest_pdfs / f"libCombineHarvesterCombinePdfs{suffix}")
 
 
 setup(cmdclass={"build_ext": CMakeBuild})


### PR DESCRIPTION
## Summary
- drop CombinePdfs package from pyproject and build configuration
- simplify setup build step to only compile and install CombineTools

## Testing
- `python -m pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `python -m pip install -e . --no-build-isolation` *(fails: Cannot import 'setuptools.build_meta')*


------
https://chatgpt.com/codex/tasks/task_e_68bbfaad33dc8329843e8e7d96ed3c1f